### PR TITLE
Remove additional make targets with `-operator` sufix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,6 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: manifests generate ## Build docker image with the operator.
-	docker build -t ${IMG} .
-
-.PHONY: docker-build-operator
-docker-build-operator: manifests generate ## Build docker image with the operator.
 	docker build -t ${IMG} -f components/operator/Dockerfile .
 
 .PHONY: docker-push
@@ -130,10 +126,6 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: module-image
 module-image: docker-build docker-push ## Build the Module Image and push it to a registry defined in IMG_REGISTRY.
-	echo "built and pushed module image $(IMG)"
-
-.PHONY: module-image-operator
-module-image-operator: docker-build-operator docker-push ## Build the Module Image and push it to a registry defined in IMG_REGISTRY.
 	echo "built and pushed module image $(IMG)"
 
 .PHONY: module-build

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -102,19 +102,6 @@ reinstall-serverless:
 
 	@make -C ${PROJECT_COMMON} verify-kyma
 
-.PHONY: reinstall-serverless-operator
-reinstall-serverless-operator:
-	@make -C ${PROJECT_COMMON} kyma \
-	  module-image-operator \
-	  module-build \
-	  fix-template \
-	  install-module-template
-
-	# wait some time to make sure lm starts the reconciliation first
-	sleep 5
-
-	@make -C ${PROJECT_COMMON} verify-kyma
-
 .PHONY: provision-gardener
 provision-gardener:
 	@make -C ${PROJECT_COMMON} provision-gardener
@@ -125,11 +112,11 @@ deprovision-gardener:
 
 .PHONY: run-with-lifecycle-manager
 run-with-lifecycle-manager:
-	@make -C ${PROJECT_COMMON} run-with-lifecycle-manager-operator
+	@make -C ${PROJECT_COMMON} run-with-lifecycle-manager
 
 .PHONY: run-without-lifecycle-manager
 run-without-lifecycle-manager:
-	@make -C ${PROJECT_COMMON} run-without-lifecycle-manager-operator
+	@make -C ${PROJECT_COMMON} run-without-lifecycle-manager
 
 .PHONY: run-without-lm-on-cluster
 run-without-lm-on-cluster:

--- a/hack/common/Makefile
+++ b/hack/common/Makefile
@@ -37,34 +37,11 @@ run-with-lifecycle-manager: kyma \
 	enable-module \
 	verify-kyma
 
-.PHONY: run-with-lifecycle-manager-operator
-run-with-lifecycle-manager-operator: ## Create k3d cluster and deploy module with the lifecycle-manager.
-run-with-lifecycle-manager-operator: kyma \
-	create-k3d \
-	module-image-operator \
-	module-build \
-	fix-template \
-	install-kyma-with-lm \
-	patch-mod-mgr-role \
-	install-module-template \
-	enable-module \
-	verify-kyma
-
-
 .PHONY: run-without-lifecycle-manager
 run-without-lifecycle-manager: ## Create k3d cluster and deploy module without the lifecycle-manager.
 run-without-lifecycle-manager: kyma \
 	create-k3d \
 	module-image \
-	deploy \
-	apply-serverless \
-	verify-serverless
-
-.PHONY: run-without-lifecycle-manager-operator
-run-without-lifecycle-manager-operator: ## Create k3d cluster and deploy module without the lifecycle-manager.
-run-without-lifecycle-manager-operator: kyma \
-	create-k3d \
-	module-image-operator \
 	deploy \
 	apply-serverless \
 	verify-serverless
@@ -168,12 +145,6 @@ kyma:
 module-image:
 	@make -C ${PROJECT_ROOT} module-image \
 		IMG=localhost:${REGISTRY_PORT}/${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}
-
-.PHONY: module-image-operator
-module-image-operator:
-	@make -C ${PROJECT_ROOT} module-image-operator \
-		IMG=localhost:${REGISTRY_PORT}/${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}
-
 
 .PHONY: module-build
 module-build:


### PR DESCRIPTION

**Description**

After merged https://github.com/kyma-project/serverless/pull/385 we don't need additional make targets with `-operator` sufix.

Changes proposed in this pull request:

- Remove additional make targets with `-operator` sufix

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/345
