### PR TITLE
Don't use sec-scanners-config to build moduletemplate on pre/post submit

### DIFF
--- a/components/operator/Makefile
+++ b/components/operator/Makefile
@@ -4,6 +4,9 @@ ifndef MODULE_VERSION
     include $(PROJECT_ROOT)/.version
 endif
 
+# Path to the sec-scanners-config file
+SEC_SCANNERS_CONFIG ?= ""
+
 # Module Name used for bundling the OCI Image and later on for referencing in the Kyma Modules
 MODULE_NAME ?= serverless
 # Module Registry used for pushing the image
@@ -132,6 +135,7 @@ module-image: docker-build docker-push ## Build the Module Image and push it to 
 module-build: ## Build the Module and push artifacts to the registry
 module-build: kyma kustomize render-manifest module-config-template configure-git-origin
 	$(KYMA) alpha create module --path $(PROJECT_ROOT) --output=$(PROJECT_ROOT)/moduletemplate.yaml \
+		--sec-scanners-config="${SEC_SCANNERS_CONFIG}" \
 		--module-config-file=$(PROJECT_ROOT)/module-config.yaml $(MODULE_CREATION_FLAGS)
 
 .PHONY: module-config-template

--- a/module-config-template.yaml
+++ b/module-config-template.yaml
@@ -3,7 +3,6 @@ channel: {{.Channel}}
 version: {{.Version}}
 defaultCR: config/samples/default-serverless-cr.yaml
 manifest: serverless-operator.yaml
-security: sec-scanners-config.yaml
 annotations:
   "operator.kyma-project.io/doc-url": "https://kyma-project.io/#/serverless-manager/user/README"
 moduleRepo: https://github.com/kyma-project/serverless-manager.git


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- we should not use sec-scanners-config to build moduletemplate because this config is used only to scan moduletemplate on production (this does not happen in this repo). In this repo, we should only test the integration and prepare ready to build module

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/411