### PR TITLE
Bump golang to 1.21.4-alpine3.18

### DIFF
--- a/components/operator/Dockerfile
+++ b/components/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM golang:1.21.3 as builder
+FROM golang:1.21.4 as builder
 
 WORKDIR /workspace
 

--- a/components/serverless/deploy/jobinit/Dockerfile
+++ b/components/serverless/deploy/jobinit/Dockerfile
@@ -1,5 +1,5 @@
-# image builder base on golang:1.21.3-alpine3.18
-FROM golang@sha256:27c76dcf886c5024320f4fa8ceb57d907494a3bb3d477d0aa7ac8385acd871ea as builder
+# image builder base on golang:1.21.4-alpine3.18
+FROM golang@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 as builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/function-controller \
     CGO_ENABLED=1 \

--- a/components/serverless/deploy/manager/Dockerfile
+++ b/components/serverless/deploy/manager/Dockerfile
@@ -1,5 +1,5 @@
-# image builder base on golang:1.21.3-alpine3.18
-FROM golang@sha256:27c76dcf886c5024320f4fa8ceb57d907494a3bb3d477d0aa7ac8385acd871ea as builder
+# image builder base on golang:1.21.4-alpine3.18
+FROM golang@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 as builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/function-controller \
     CGO_ENABLED=1 \

--- a/components/serverless/deploy/registry-gc/Dockerfile
+++ b/components/serverless/deploy/registry-gc/Dockerfile
@@ -1,5 +1,5 @@
-# image builder base on golang:1.21.3-alpine3.18
-FROM golang@sha256:27c76dcf886c5024320f4fa8ceb57d907494a3bb3d477d0aa7ac8385acd871ea as builder
+# image builder base on golang:1.21.4-alpine3.18
+FROM golang@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 as builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/function-controller \
     CGO_ENABLED=1 \

--- a/components/serverless/deploy/webhook/Dockerfile
+++ b/components/serverless/deploy/webhook/Dockerfile
@@ -1,5 +1,5 @@
-# image builder base on golang:1.21.3-alpine3.18
-FROM golang@sha256:27c76dcf886c5024320f4fa8ceb57d907494a3bb3d477d0aa7ac8385acd871ea as builder
+# image builder base on golang:1.21.4-alpine3.18
+FROM golang@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 as builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/kyma/components/function-controller \
     CGO_ENABLED=0 \

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -98,16 +98,16 @@ global:
       directory: "dev"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "v20231010-c44aa328"
+      version: "v20231113-e18796c5"
       directory: "prod"
     function_runtime_nodejs18:
       name: "function-runtime-nodejs18"
-      version: "v20231010-c44aa328"
+      version: "v20231113-e18796c5"
       directory: "prod"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-369"
-      directory: "dev"
+      version: "v20231113-e18796c5"
+      directory: "prod"
     kaniko_executor:
       name: "tpi/kaniko-executor"
       version: "1.9.1-406380b9"

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -82,19 +82,19 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-420"
+      version: "PR-428"
       directory: "dev"
     function_webhook:
       name: "function-webhook"
-      version: "PR-420"
+      version: "PR-428"
       directory: "dev"
     function_build_init:
       name: "function-build-init"
-      version: "PR-420"
+      version: "PR-428"
       directory: "dev"
     function_registry_gc:
       name: "function-registry-gc"
-      version: "PR-420"
+      version: "PR-428"
       directory: "dev"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bring latest security patches from golang:1.21.4-alpine3.18
