### PR TITLE
Dynamically exclude namespaces

### DIFF
--- a/components/operator/internal/chart/flags.go
+++ b/components/operator/internal/chart/flags.go
@@ -15,6 +15,7 @@ type FlagsBuilder interface {
 	WithRegistryEnableInternal(enableInternal bool) *flagsBuilder
 	WithRegistryHttpSecret(httpSecret string) *flagsBuilder
 	WithNodePort(nodePort int64) *flagsBuilder
+	WithExcludedNamespace(excludedNamespace string) *flagsBuilder
 }
 
 type flagsBuilder struct {
@@ -125,6 +126,12 @@ func (fb *flagsBuilder) WithDefaultPresetFlags(defaultBuildJobPreset, defaultRun
 	if defaultBuildJobPreset != "" {
 		fb.flags["webhook.values.buildJob.resources.defaultPreset"] = defaultBuildJobPreset
 	}
+
+	return fb
+}
+
+func (fb *flagsBuilder) WithExcludedNamespace(excludedNamespace string) *flagsBuilder {
+	fb.flags["containers.manager.configuration.data.namespaceExcludedNames"] = excludedNamespace
 
 	return fb
 }

--- a/components/operator/internal/chart/flags.go
+++ b/components/operator/internal/chart/flags.go
@@ -15,7 +15,7 @@ type FlagsBuilder interface {
 	WithRegistryEnableInternal(enableInternal bool) *flagsBuilder
 	WithRegistryHttpSecret(httpSecret string) *flagsBuilder
 	WithNodePort(nodePort int64) *flagsBuilder
-	WithExcludedNamespace(excludedNamespace string) *flagsBuilder
+	WithExcludedNamespaces(excludedNamespaces []string) *flagsBuilder
 }
 
 type flagsBuilder struct {
@@ -130,8 +130,8 @@ func (fb *flagsBuilder) WithDefaultPresetFlags(defaultBuildJobPreset, defaultRun
 	return fb
 }
 
-func (fb *flagsBuilder) WithExcludedNamespace(excludedNamespace string) *flagsBuilder {
-	fb.flags["containers.manager.configuration.data.namespaceExcludedNames"] = excludedNamespace
+func (fb *flagsBuilder) WithExcludedNamespaces(excludedNamespaces []string) *flagsBuilder {
+	fb.flags["containers.manager.configuration.data.namespaceExcludedNames"] = strings.Join(excludedNamespaces, ";")
 
 	return fb
 }

--- a/components/operator/internal/chart/flags_test.go
+++ b/components/operator/internal/chart/flags_test.go
@@ -27,7 +27,7 @@ func Test_flagsBuilder_Build(t *testing.T) {
 							"functionTraceCollectorEndpoint":   "testCollectorURL",
 							"healthzLivenessTimeout":           "testHealthzLivenessTimeout",
 							"targetCPUUtilizationPercentage":   "testCPUUtilizationPercentage",
-							"namespaceExcludedNames":           "testNamespace",
+							"namespaceExcludedNames":           "testNamespace;testNamespace2",
 						},
 					},
 				},
@@ -78,7 +78,7 @@ func Test_flagsBuilder_Build(t *testing.T) {
 				"testRequestBodyLimitMb",
 				"testTimeoutSec",
 			).
-			WithExcludedNamespace("testNamespace").Build()
+			WithExcludedNamespaces([]string{"testNamespace", "testNamespace2"}).Build()
 
 		require.Equal(t, expectedFlags, flags)
 	})

--- a/components/operator/internal/chart/flags_test.go
+++ b/components/operator/internal/chart/flags_test.go
@@ -27,6 +27,7 @@ func Test_flagsBuilder_Build(t *testing.T) {
 							"functionTraceCollectorEndpoint":   "testCollectorURL",
 							"healthzLivenessTimeout":           "testHealthzLivenessTimeout",
 							"targetCPUUtilizationPercentage":   "testCPUUtilizationPercentage",
+							"namespaceExcludedNames":           "testNamespace",
 						},
 					},
 				},
@@ -76,7 +77,8 @@ func Test_flagsBuilder_Build(t *testing.T) {
 				"testHealthzLivenessTimeout",
 				"testRequestBodyLimitMb",
 				"testTimeoutSec",
-			).Build()
+			).
+			WithExcludedNamespace("testNamespace").Build()
 
 		require.Equal(t, expectedFlags, flags)
 	})

--- a/components/operator/internal/state/registry.go
+++ b/components/operator/internal/state/registry.go
@@ -68,7 +68,9 @@ func configureRegistry(ctx context.Context, r *reconciler, s *systemState) error
 		// case: use k3d registry
 		setK3dRegistryConfig(s)
 	}
+
 	setExcludedNamespace(s)
+
 	addRegistryConfigurationWarnings(extRegSecretClusterWide, extRegSecretNamespacedScope, s)
 	return nil
 }

--- a/components/operator/internal/state/registry.go
+++ b/components/operator/internal/state/registry.go
@@ -69,7 +69,7 @@ func configureRegistry(ctx context.Context, r *reconciler, s *systemState) error
 		setK3dRegistryConfig(s)
 	}
 
-	setExcludedNamespace(s)
+	setExcludedNamespaces(s)
 
 	addRegistryConfigurationWarnings(extRegSecretClusterWide, extRegSecretNamespacedScope, s)
 	return nil

--- a/components/operator/internal/state/registry.go
+++ b/components/operator/internal/state/registry.go
@@ -181,9 +181,9 @@ func getRegistrySecret(ctx context.Context, r *reconciler, s *systemState) (*cor
 	return &secret, err
 }
 
-func setExcludedNamespace(s *systemState) {
+func setExcludedNamespaces(s *systemState) {
 	excludedNamespace := s.instance.Namespace
-	s.flagsBuilder.WithExcludedNamespace(excludedNamespace)
+	s.flagsBuilder.WithExcludedNamespaces([]string{excludedNamespace})
 }
 
 func isRegistrySecretName(registry *v1alpha1.DockerRegistry) bool {

--- a/components/operator/internal/state/registry.go
+++ b/components/operator/internal/state/registry.go
@@ -68,7 +68,7 @@ func configureRegistry(ctx context.Context, r *reconciler, s *systemState) error
 		// case: use k3d registry
 		setK3dRegistryConfig(s)
 	}
-
+	setExcludedNamespace(s)
 	addRegistryConfigurationWarnings(extRegSecretClusterWide, extRegSecretNamespacedScope, s)
 	return nil
 }
@@ -177,6 +177,11 @@ func getRegistrySecret(ctx context.Context, r *reconciler, s *systemState) (*cor
 	}
 	err := r.client.Get(ctx, key, &secret)
 	return &secret, err
+}
+
+func setExcludedNamespace(s *systemState) {
+	excludedNamespace := s.instance.Namespace
+	s.flagsBuilder.WithExcludedNamespace(excludedNamespace)
 }
 
 func isRegistrySecretName(registry *v1alpha1.DockerRegistry) bool {

--- a/components/operator/internal/state/registry_test.go
+++ b/components/operator/internal/state/registry_test.go
@@ -37,6 +37,15 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 			log: zap.NewNop().Sugar(),
 		}
 		expectedFlags := map[string]interface{}{
+			"containers": map[string]interface{}{
+				"manager": map[string]interface{}{
+					"configuration": map[string]interface{}{
+						"data": map[string]interface{}{
+							"namespaceExcludedNames": "",
+						},
+					},
+				},
+			},
 			"dockerRegistry": map[string]interface{}{
 				"enableInternal": true,
 			},
@@ -93,6 +102,15 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 			},
 		}
 		expectedFlags := map[string]interface{}{
+			"containers": map[string]interface{}{
+				"manager": map[string]interface{}{
+					"configuration": map[string]interface{}{
+						"data": map[string]interface{}{
+							"namespaceExcludedNames": "",
+						},
+					},
+				},
+			},
 			"dockerRegistry": map[string]interface{}{
 				"enableInternal":  false,
 				"username":        string(secret.Data["username"]),
@@ -135,6 +153,15 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 			},
 		}
 		expectedFlags := map[string]interface{}{
+			"containers": map[string]interface{}{
+				"manager": map[string]interface{}{
+					"configuration": map[string]interface{}{
+						"data": map[string]interface{}{
+							"namespaceExcludedNames": "",
+						},
+					},
+				},
+			},
 			"dockerRegistry": map[string]interface{}{
 				"enableInternal":  false,
 				"registryAddress": v1alpha1.DefaultRegistryAddress,

--- a/components/operator/internal/state/registry_test.go
+++ b/components/operator/internal/state/registry_test.go
@@ -41,7 +41,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 				"manager": map[string]interface{}{
 					"configuration": map[string]interface{}{
 						"data": map[string]interface{}{
-							"namespaceExcludedNames": "",
+							"namespaceExcludedNames": "kyma-test",
 						},
 					},
 				},
@@ -106,7 +106,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 				"manager": map[string]interface{}{
 					"configuration": map[string]interface{}{
 						"data": map[string]interface{}{
-							"namespaceExcludedNames": "",
+							"namespaceExcludedNames": "kyma-test",
 						},
 					},
 				},
@@ -157,7 +157,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 				"manager": map[string]interface{}{
 					"configuration": map[string]interface{}{
 						"data": map[string]interface{}{
-							"namespaceExcludedNames": "",
+							"namespaceExcludedNames": "kyma-test",
 						},
 					},
 				},

--- a/components/operator/internal/state/registry_test.go
+++ b/components/operator/internal/state/registry_test.go
@@ -41,7 +41,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 				"manager": map[string]interface{}{
 					"configuration": map[string]interface{}{
 						"data": map[string]interface{}{
-							"namespaceExcludedNames": "kyma-test",
+							"namespaceExcludedNames": "",
 						},
 					},
 				},
@@ -134,7 +134,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.Serverless{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "some-namespace",
+					Namespace: "kyma-test",
 				},
 				Spec: v1alpha1.ServerlessSpec{
 					DockerRegistry: &v1alpha1.DockerRegistry{
@@ -239,7 +239,17 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 			k8s: k8s{client: client},
 			log: zap.NewNop().Sugar(),
 		}
-		expectedFlags := map[string]interface{}{}
+		expectedFlags := map[string]interface{}{
+			"containers": map[string]interface{}{
+				"manager": map[string]interface{}{
+					"configuration": map[string]interface{}{
+						"data": map[string]interface{}{
+							"namespaceExcludedNames": "kyma-test",
+						},
+					},
+				},
+			},
+		}
 
 		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
 		require.NoError(t, err)

--- a/components/serverless/internal/controllers/kubernetes/shared.go
+++ b/components/serverless/internal/controllers/kubernetes/shared.go
@@ -20,7 +20,7 @@ const (
 type Config struct {
 	BaseNamespace                 string        `envconfig:"default=kyma-system"`
 	BaseDefaultSecretName         string        `envconfig:"default=serverless-registry-config-default"`
-	ExcludedNamespaces            []string      `envconfig:"default=istio-system;kube-node-lease;kube-public;kube-system;kyma-installer;kyma-system;natss"`
+	ExcludedNamespaces            []string      `envconfig:"default=kyma-system"`
 	ConfigMapRequeueDuration      time.Duration `envconfig:"default=1m"`
 	SecretRequeueDuration         time.Duration `envconfig:"default=1m"`
 	ServiceAccountRequeueDuration time.Duration `envconfig:"default=1m"`

--- a/components/serverless/internal/controllers/kubernetes/shared_test.go
+++ b/components/serverless/internal/controllers/kubernetes/shared_test.go
@@ -79,7 +79,7 @@ func TestConfigStruct_ExcludedNamespaceDefaultValue(t *testing.T) {
 		err := envconfig.Init(&cfg)
 		g.Expect(err).To(gomega.Succeed())
 
-		g.Expect(cfg.ExcludedNamespaces).NotTo(gomega.HaveLen(1))
+		g.Expect(cfg.ExcludedNamespaces).To(gomega.HaveLen(1))
 	})
 }
 


### PR DESCRIPTION
**Description**
Removed default excluded namespaces and replaced them with logic that only excludes namespace used by the serverless

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/241
