### PR TITLE
remove env validation from webhook

### DIFF
--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -50,7 +50,6 @@ func (fn *Function) getBasicValidations() []validationFunction {
 	return []validationFunction{
 		fn.validateObjectMeta,
 		fn.Spec.validateRuntime,
-		fn.Spec.validateEnv,
 		fn.Spec.validateLabels,
 		fn.Spec.validateAnnotations,
 		fn.Spec.validateSources,
@@ -166,26 +165,6 @@ func (spec *FunctionSpec) validateRuntime(_ *ValidationConfig) error {
 		return nil
 	}
 	return fmt.Errorf("spec.runtime contains unsupported value")
-}
-
-func (spec *FunctionSpec) validateEnv(vc *ValidationConfig) error {
-	var allErrs []string
-	envs := spec.Env
-	reservedEnvs := vc.ReservedEnvs
-	for _, env := range envs {
-		errs := utilvalidation.IsEnvVarName(env.Name)
-		for _, reservedEnv := range reservedEnvs {
-			if env.Name == reservedEnv {
-				errs = append(errs, "env name is reserved for the serverless domain")
-			}
-		}
-		if len(errs) > 0 {
-			allErrs = append(allErrs,
-				errs...,
-			)
-		}
-	}
-	return returnAllErrs("invalid spec.env keys/values", allErrs)
 }
 
 func (spec *FunctionSpec) validateFunctionResources(vc *ValidationConfig) error {

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -237,35 +237,6 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 				),
 			),
 		},
-		"Should return error on env validation": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Runtime: NodeJs18,
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "test",
-							Value: "test",
-						},
-						{
-							Name:  "K_CONFIGURATION",
-							Value: "should reject this",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring(
-					"spec.env",
-				),
-			),
-		},
 		"Should return error on spec/template/labels validation": {
 			givenFunc: Function{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -76,15 +76,15 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-471"
+      version: "PR-476"
       directory: "dev"
     function_webhook:
       name: "function-webhook"
-      version: "PR-471"
+      version: "PR-476"
       directory: "dev"
     function_build_init:
       name: "function-build-init"
-      version: "PR-471"
+      version: "PR-476"
       directory: "dev"
     function_registry_gc:
       name: "function-registry-gc"


### PR DESCRIPTION
**Description**

Remove `env` validation from webhook. 
It was moved to x-kubernetes-validation: 
  https://github.com/kyma-project/serverless/pull/367/files#diff-77e8223c0503167a80e6634cadf9b409b466cae6dc25c4da40a44d7e6af5f65dR173
and to controller:
  https://github.com/kyma-project/serverless/pull/469/files#diff-6ec69b4ade03be6b2aa75a237868f357035f4dec4ef38e41792b95cf06acc272R69-R79

**Related issue(s)**
See also #250 