### PR TITLE
remove runtime validation from webhook

### DIFF
--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -44,7 +44,6 @@ type validationFunction func(*ValidationConfig) error
 func (fn *Function) getBasicValidations() []validationFunction {
 	return []validationFunction{
 		fn.validateObjectMeta,
-		fn.Spec.validateRuntime,
 		fn.Spec.validateLabels,
 		fn.Spec.validateAnnotations,
 		fn.Spec.validateSources,
@@ -151,15 +150,6 @@ func (spec *FunctionSpec) validateGitAuthType(_ *ValidationConfig) error {
 	default:
 		return ErrInvalidGitRepositoryAuthType
 	}
-}
-
-func (spec *FunctionSpec) validateRuntime(_ *ValidationConfig) error {
-	runtimeName := spec.Runtime
-	switch runtimeName {
-	case Python39, NodeJs16, NodeJs18:
-		return nil
-	}
-	return fmt.Errorf("spec.runtime contains unsupported value")
 }
 
 func (spec *FunctionSpec) validateSources(vc *ValidationConfig) error {

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -135,43 +135,6 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 			},
 			expectedError: gomega.BeNil(),
 		},
-		"Should return error on unexpected runtime name": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Runtime: "unknown-runtime-name",
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring(
-					"spec.runtime",
-				),
-			),
-		},
-		"Should return error on empty runtime name": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring(
-					"spec.runtime",
-				),
-			),
-		},
 		"Should return error when more than one source is filled": {
 			givenFunc: Function{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -76,15 +76,15 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-482"
+      version: "PR-483"
       directory: "dev"
     function_webhook:
       name: "function-webhook"
-      version: "PR-482"
+      version: "PR-483"
       directory: "dev"
     function_build_init:
       name: "function-build-init"
-      version: "PR-482"
+      version: "PR-483"
       directory: "dev"
     function_registry_gc:
       name: "function-registry-gc"


### PR DESCRIPTION
**Description**

Remove runtime field validation from webhook.

Validation was moved to x-kubernetes-validations in: https://github.com/kyma-project/serverless/pull/365

**Related issue(s)**
See also #250 