### PR TITLE
Validate secret mounts to controller

### DIFF
--- a/components/serverless/internal/controllers/serverless/validation_test.go
+++ b/components/serverless/internal/controllers/serverless/validation_test.go
@@ -319,7 +319,7 @@ func TestValidation(t *testing.T) {
 			updatedFn := serverlessv1alpha2.Function{}
 			require.NoError(t, resourceClient.Get(ctx, ctrlclient.ObjectKey{Name: tc.fn.Name}, &updatedFn))
 			cond := getCondition(updatedFn.Status.Conditions, serverlessv1alpha2.ConditionConfigurationReady)
-			assert.Equal(t, cond.Reason, serverlessv1alpha2.ConditionReasonFunctionSpec)
+			assert.Equal(t, serverlessv1alpha2.ConditionReasonFunctionSpec, cond.Reason)
 			assert.Equal(t, corev1.ConditionFalse, cond.Status)
 			assert.NotEmpty(t, tc.expectedCondMsg, "expected message shouldn't be empty")
 			assert.Equal(t, tc.expectedCondMsg, cond.Message)
@@ -349,6 +349,12 @@ func TestValidation(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "_CORRECT_ENV"},
 					{Name: "ANOTHER_CORRECT_ENV"},
+				},
+				SecretMounts: []serverlessv1alpha2.SecretMount{
+					{
+						SecretName: "secret-name",
+						MountPath:  "mount-path",
+					},
 				},
 			},
 		}

--- a/components/serverless/internal/controllers/serverless/validation_test.go
+++ b/components/serverless/internal/controllers/serverless/validation_test.go
@@ -298,6 +298,46 @@ func TestValidation(t *testing.T) {
 			},
 			expectedCondMsg: "spec.env: 1ENV. Err: a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')",
 		},
+		"Invalid secretMount name": {
+			fn: serverlessv1alpha2.Function{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
+				Spec: serverlessv1alpha2.FunctionSpec{
+					SecretMounts: []serverlessv1alpha2.SecretMount{
+						{
+							SecretName: "secret-name-1",
+							MountPath:  "/mount/path/1",
+						},
+						{
+							SecretName: "invalid secret name - not DNS subdomain name as defined in RFC 1123",
+							MountPath:  "/mount/path/2",
+						},
+					},
+				},
+			},
+			expectedCondMsg: "invalid spec.secretMounts: [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+		},
+		"Non unique secretMount name": {
+			fn: serverlessv1alpha2.Function{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
+				Spec: serverlessv1alpha2.FunctionSpec{
+					SecretMounts: []serverlessv1alpha2.SecretMount{
+						{
+							SecretName: "secret-name-1",
+							MountPath:  "/mount/path/1",
+						},
+						{
+							SecretName: "non-unique-secret-name",
+							MountPath:  "/mount/path/2",
+						},
+						{
+							SecretName: "non-unique-secret-name",
+							MountPath:  "/mount/path/3",
+						},
+					},
+				},
+			},
+			expectedCondMsg: "invalid spec.secretMounts: [secretNames should be unique]",
+		},
 	}
 
 	//WHEN

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -199,10 +199,6 @@ func (spec *FunctionSpec) validateSecretMounts(_ *ValidationConfig) error {
 		allErrs = append(allErrs, "secretNames should be unique")
 	}
 
-	if !secretMountPathAreNotEmpty(secretMounts) {
-		allErrs = append(allErrs, "mountPath should not be empty")
-	}
-
 	return returnAllErrs("invalid spec.secretMounts", allErrs)
 }
 

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	v1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -46,7 +45,6 @@ func (fn *Function) getBasicValidations() []validationFunction {
 		fn.validateObjectMeta,
 		fn.Spec.validateLabels,
 		fn.Spec.validateAnnotations,
-		fn.Spec.validateSecretMounts,
 	}
 }
 
@@ -185,38 +183,6 @@ func (spec *FunctionSpec) validateAnnotations(_ *ValidationConfig) error {
 	errs := validation.ValidateAnnotations(spec.Annotations, fieldPath)
 
 	return errs.ToAggregate()
-}
-
-func (spec *FunctionSpec) validateSecretMounts(_ *ValidationConfig) error {
-	var allErrs []string
-	secretMounts := spec.SecretMounts
-	for _, secretMount := range secretMounts {
-		allErrs = append(allErrs,
-			utilvalidation.IsDNS1123Subdomain(secretMount.SecretName)...)
-	}
-
-	if !secretNamesAreUnique(secretMounts) {
-		allErrs = append(allErrs, "secretNames should be unique")
-	}
-
-	return returnAllErrs("invalid spec.secretMounts", allErrs)
-}
-
-func secretNamesAreUnique(secretMounts []SecretMount) bool {
-	uniqueSecretNames := make(map[string]bool)
-	for _, secretMount := range secretMounts {
-		uniqueSecretNames[secretMount.SecretName] = true
-	}
-	return len(uniqueSecretNames) == len(secretMounts)
-}
-
-func secretMountPathAreNotEmpty(secretMounts []SecretMount) bool {
-	for _, secretMount := range secretMounts {
-		if secretMount.MountPath == "" {
-			return false
-		}
-	}
-	return true
 }
 
 type property struct {

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -432,29 +432,6 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 				gomega.ContainSubstring("secretNames should be unique"),
 			),
 		},
-		"Should return error when validate empty mountPath in secretMounts": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Runtime: NodeJs18,
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-					SecretMounts: []SecretMount{
-						{
-							SecretName: "secret-name-1",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring("spec.secretMounts"),
-				gomega.ContainSubstring("mountPath should not be empty"),
-			),
-		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			tn := testName

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -372,66 +372,6 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 			},
 			expectedError: gomega.BeNil(),
 		},
-		"Should return error when validate invalid secretName in secretMounts": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Runtime: NodeJs18,
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-					SecretMounts: []SecretMount{
-						{
-							SecretName: "secret-name-1",
-							MountPath:  "/mount/path/1",
-						},
-						{
-							SecretName: "invalid secret name - not DNS subdomain name as defined in RFC 1123",
-							MountPath:  "/mount/path/2",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring("spec.secretMounts"),
-				gomega.ContainSubstring("RFC 1123 subdomain"),
-			),
-		},
-		"Should return error when validate non unique secretName in secretMounts": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Runtime: NodeJs18,
-					Source: Source{
-						Inline: &InlineSource{
-							Source: "test-source",
-						},
-					},
-					SecretMounts: []SecretMount{
-						{
-							SecretName: "secret-name-1",
-							MountPath:  "/mount/path/1",
-						},
-						{
-							SecretName: "non-unique-secret-name",
-							MountPath:  "/mount/path/2",
-						},
-						{
-							SecretName: "non-unique-secret-name",
-							MountPath:  "/mount/path/3",
-						},
-					},
-				},
-			},
-			expectedError: gomega.HaveOccurred(),
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring("spec.secretMounts"),
-				gomega.ContainSubstring("secretNames should be unique"),
-			),
-		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			tn := testName

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -76,15 +76,15 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-491"
+      version: "PR-493"
       directory: "dev"
     function_webhook:
       name: "function-webhook"
-      version: "PR-491"
+      version: "PR-493"
       directory: "dev"
     function_build_init:
       name: "function-build-init"
-      version: "PR-491"
+      version: "PR-493"
       directory: "dev"
     function_registry_gc:
       name: "function-registry-gc"


### PR DESCRIPTION
**Description**
Move secretMounts validation to controller.

Some changes was done before in: https://github.com/kyma-project/serverless/pull/375

**Related issue(s)**
See also #250 