### PR TITLE
Use same tpi images in sec-scanners-config and values

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -5,8 +5,8 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/function-controller:main
   - europe-docker.pkg.dev/kyma-project/prod/function-build-init:main
   - europe-docker.pkg.dev/kyma-project/prod/function-webhook:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/registry:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/kaniko-executor:main
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/registry:2.8.1-1ae4c190
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/kaniko-executor:1.9.1-1ae4c190
   - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs16:main
   - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs18:main
   - europe-docker.pkg.dev/kyma-project/prod/function-runtime-python39:main


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- tpi images should not use `main` tag because these images are in different repos and it's not possible to bump these images using a serverless release tag (for example `1.2.2`)
