### PR TITLE
Set app.kubernetes.io/name label for better function instrumentation

### DIFF
--- a/components/runtimes/nodejs/lib/metrics.js
+++ b/components/runtimes/nodejs/lib/metrics.js
@@ -6,12 +6,9 @@ const { SemanticResourceAttributes } = require( '@opentelemetry/semantic-convent
 
 let exporter;
 
-function setupMetrics(serviceName){
+function setupMetrics(){
 
-    const resource = new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
-    });
-
+    const resource = new Resource();
 
     const myServiceMeterProvider = new MeterProvider({
     resource,

--- a/components/runtimes/nodejs/lib/tracer.js
+++ b/components/runtimes/nodejs/lib/tracer.js
@@ -7,7 +7,6 @@ const { NodeTracerProvider } = require( '@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor } = require( '@opentelemetry/sdk-trace-base');
 const { OTLPTraceExporter } =  require('@opentelemetry/exporter-trace-otlp-http');
 const { Resource } = require( '@opentelemetry/resources');
-const { SemanticResourceAttributes } = require( '@opentelemetry/semantic-conventions');
 const { B3Propagator, B3InjectEncoding } = require("@opentelemetry/propagator-b3");
 const { ExpressInstrumentation, ExpressLayerType } = require( '@opentelemetry/instrumentation-express');
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
@@ -18,12 +17,10 @@ const ignoredTargets = [
   "/healthz", "/favicon.ico", "/metrics"
 ]
 
-function setupTracer(serviceName){
+function setupTracer(){
 
   const provider = new NodeTracerProvider({
-    resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
-    }),
+    resource: new Resource(),
     sampler: new ParentBasedSampler({
       root: new AlwaysOnSampler()
     }),
@@ -64,7 +61,7 @@ function setupTracer(serviceName){
     propagator: propagator,
   });
 
-  return opentelemetry.trace.getTracer(serviceName);
+  return opentelemetry.trace.getTracer("tracer");
 };
 
 module.exports = {

--- a/components/runtimes/nodejs/server.js
+++ b/components/runtimes/nodejs/server.js
@@ -20,13 +20,12 @@ const functionName = process.env.FUNC_NAME;
 const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
 const funcPort = Number(process.env.FUNC_PORT || '8080');
 
-const otelServiceName = [functionName, serviceNamespace].join('.')
-const tracer = setupTracer(otelServiceName);
-setupMetrics(otelServiceName);
+const tracer = setupTracer();
+setupMetrics();
 
-const callsTotalCounter = createFunctionCallsTotalCounter(otelServiceName);
-const failuresTotalCounter = createFunctionFailuresTotalCounter(otelServiceName);
-const durationHistogram = createFunctionDurationHistogram(otelServiceName);
+const callsTotalCounter = createFunctionCallsTotalCounter(functionName);
+const failuresTotalCounter = createFunctionFailuresTotalCounter(functionName);
+const durationHistogram = createFunctionDurationHistogram(functionName);
 
 //require express must be called AFTER tracer was setup!!!!!!
 const express = require("express");

--- a/components/runtimes/python39/kubeless/kubeless.py
+++ b/components/runtimes/python39/kubeless/kubeless.py
@@ -44,18 +44,15 @@ bottle.BaseRequest.MEMFILE_MAX = memfile_max
 app = application = bottle.app()
 
 function_context = {
-    'function-name': func.__name__,
+    'function-name': os.getenv('FUNC_NAME'),
+    'namespace': os.getenv('SERVICE_NAMESPACE'),
     'timeout': timeout,
     'runtime': os.getenv('FUNC_RUNTIME'),
     'memory-limit': os.getenv('FUNC_MEMORY_LIMIT'),
 }
 
-function_name = os.getenv('FUNC_NAME')
-service_namespace = os.getenv('SERVICE_NAMESPACE')
-service_name = '.'.join([function_name, service_namespace])
-
 if __name__ == "__main__":
-    tracer = tracing._setup_tracer(service_name)
+    tracer = tracing._setup_tracer()
 
 
 def func_with_context(e, function_context):

--- a/components/runtimes/python39/kubeless/tracing.py
+++ b/components/runtimes/python39/kubeless/tracing.py
@@ -5,10 +5,8 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider, _Span
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.propagate import extract
-from opentelemetry.sdk.resources import (
-    SERVICE_NAME,
-    Resource
-)
+from opentelemetry.sdk.resources import Resource
+
 from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
 )
@@ -24,10 +22,10 @@ import os
 
 # Tracing propagators are configured based on OTEL_PROPAGATORS env variable set in dockerfile
 # https://opentelemetry.io/docs/instrumentation/python/manual/#using-environment-variables
-def _setup_tracer(service_name: str) -> trace.Tracer:
+def _setup_tracer() -> trace.Tracer:
 
     provider = TracerProvider(
-        resource=Resource.create({SERVICE_NAME: service_name}),
+        resource=Resource.create(),
         sampler=DEFAULT_ON,
     )
    

--- a/components/serverless/internal/controllers/serverless/build_resources_test.go
+++ b/components/serverless/internal/controllers/serverless/build_resources_test.go
@@ -110,7 +110,7 @@ func TestFunctionReconciler_buildDeployment(t *testing.T) {
 			g.Expect(got.Spec.Template.Spec.Containers[0].Env).To(gomega.ContainElements(rtmCfg.RuntimeEnvs))
 
 			// pod labels & annotations
-			g.Expect(got.Spec.Template.ObjectMeta.Labels).To(gomega.HaveLen(4 + 3))
+			g.Expect(got.Spec.Template.ObjectMeta.Labels).To(gomega.HaveLen(5 + 3))
 			g.Expect(got.Spec.Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue("foo", "bar"))
 			g.Expect(got.Spec.Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue(testBindingLabel1, "foobar"))
 			g.Expect(got.Spec.Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue(testBindingLabel2, testBindingLabelValue))

--- a/components/serverless/internal/controllers/serverless/function_reconcile_asserts_test.go
+++ b/components/serverless/internal/controllers/serverless/function_reconcile_asserts_test.go
@@ -120,8 +120,9 @@ func assertSuccessfulFunctionDeployment(t *testing.T, resourceClient resource.Cl
 	}
 
 	g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal(s.buildImageAddress(regPullAddr)))
-	g.Expect(deployment.Spec.Template.Labels).To(gomega.HaveLen(7))
+	g.Expect(deployment.Spec.Template.Labels).To(gomega.HaveLen(8))
 	g.Expect(deployment.Spec.Template.Labels[serverlessv1alpha2.FunctionNameLabel]).To(gomega.Equal(function.Name))
+	g.Expect(deployment.Spec.Template.Labels[serverlessv1alpha2.PodAppNameLabel]).To(gomega.Equal(function.Name))
 	g.Expect(deployment.Spec.Template.Labels[serverlessv1alpha2.FunctionManagedByLabel]).To(gomega.Equal(serverlessv1alpha2.FunctionControllerValue))
 	g.Expect(deployment.Spec.Template.Labels[serverlessv1alpha2.FunctionUUIDLabel]).To(gomega.Equal(string(function.UID)))
 	g.Expect(deployment.Spec.Template.Labels[serverlessv1alpha2.FunctionResourceLabel]).To(gomega.Equal(serverlessv1alpha2.FunctionResourceLabelDeploymentValue))

--- a/components/serverless/internal/controllers/serverless/function_reconcile_gitops_test.go
+++ b/components/serverless/internal/controllers/serverless/function_reconcile_gitops_test.go
@@ -322,8 +322,9 @@ func TestGitOpsWithContinuousGitCheckout(t *testing.T) {
 			expectedImage := s.buildImageAddress("localhost:32132")
 			g.Expect(deployment).To(gomega.Not(gomega.BeNil()))
 			g.Expect(deployment).To(haveSpecificContainer0Image(expectedImage))
-			g.Expect(deployment).To(haveLabelLen(7))
+			g.Expect(deployment).To(haveLabelLen(8))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionNameLabel, function.Name))
+			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.PodAppNameLabel, function.Name))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionManagedByLabel, serverlessv1alpha2.FunctionControllerValue))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionUUIDLabel, string(function.UID)))
 			g.Expect(deployment).To(haveLabelWithValue(
@@ -569,8 +570,9 @@ func TestGitOpsWithoutContinuousGitCheckout(t *testing.T) {
 			expectedImage := s.buildImageAddress("localhost:32132")
 			g.Expect(deployment).To(gomega.Not(gomega.BeNil()))
 			g.Expect(deployment).To(haveSpecificContainer0Image(expectedImage))
-			g.Expect(deployment).To(haveLabelLen(7))
+			g.Expect(deployment).To(haveLabelLen(8))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionNameLabel, function.Name))
+			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.PodAppNameLabel, function.Name))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionManagedByLabel, serverlessv1alpha2.FunctionControllerValue))
 			g.Expect(deployment).To(haveLabelWithValue(serverlessv1alpha2.FunctionUUIDLabel, string(function.UID)))
 			g.Expect(deployment).To(haveLabelWithValue(

--- a/components/serverless/internal/controllers/serverless/system_state.go
+++ b/components/serverless/internal/controllers/serverless/system_state.go
@@ -363,7 +363,7 @@ func (s *systemState) podLabels() map[string]string {
 	if s.instance.Spec.Labels != nil {
 		result = labels.Merge(s.instance.Spec.Labels, result)
 	}
-	return result
+	return labels.Merge(result, map[string]string{serverlessv1alpha2.PodAppNameLabel: s.instance.Name})
 }
 
 func (s *systemState) defaultAnnotations() map[string]string {

--- a/components/serverless/internal/controllers/serverless/system_state_test.go
+++ b/components/serverless/internal/controllers/serverless/system_state_test.go
@@ -1,10 +1,11 @@
 package serverless
 
 import (
+	"testing"
+
 	"github.com/kyma-project/serverless/components/serverless/pkg/apis/serverless/v1alpha2"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_systemState_podLabels(t *testing.T) {
@@ -25,6 +26,7 @@ func Test_systemState_podLabels(t *testing.T) {
 				}},
 			},
 			want: map[string]string{
+				v1alpha2.PodAppNameLabel:        "fn-name",
 				v1alpha2.FunctionUUIDLabel:      "fn-uuid",
 				v1alpha2.FunctionManagedByLabel: v1alpha2.FunctionControllerValue,
 				v1alpha2.FunctionNameLabel:      "fn-name",
@@ -44,6 +46,7 @@ func Test_systemState_podLabels(t *testing.T) {
 					},
 				}}},
 			want: map[string]string{
+				v1alpha2.PodAppNameLabel:        "fn-name",
 				v1alpha2.FunctionUUIDLabel:      "fn-uuid",
 				v1alpha2.FunctionManagedByLabel: v1alpha2.FunctionControllerValue,
 				v1alpha2.FunctionNameLabel:      "fn-name",
@@ -66,6 +69,7 @@ func Test_systemState_podLabels(t *testing.T) {
 					},
 				}}},
 			want: map[string]string{
+				v1alpha2.PodAppNameLabel:        "fn-name",
 				v1alpha2.FunctionUUIDLabel:      "fn-uuid",
 				v1alpha2.FunctionManagedByLabel: v1alpha2.FunctionControllerValue,
 				v1alpha2.FunctionNameLabel:      "fn-name",
@@ -85,6 +89,7 @@ func Test_systemState_podLabels(t *testing.T) {
 					},
 				}}},
 			want: map[string]string{
+				v1alpha2.PodAppNameLabel:        "fn-name",
 				v1alpha2.FunctionUUIDLabel:      "fn-uuid",
 				v1alpha2.FunctionManagedByLabel: v1alpha2.FunctionControllerValue,
 				v1alpha2.FunctionNameLabel:      "fn-name",
@@ -107,6 +112,7 @@ func Test_systemState_podLabels(t *testing.T) {
 					},
 				}}},
 			want: map[string]string{
+				v1alpha2.PodAppNameLabel:        "fn-name",
 				v1alpha2.FunctionUUIDLabel:      "fn-uuid",
 				v1alpha2.FunctionManagedByLabel: v1alpha2.FunctionControllerValue,
 				v1alpha2.FunctionNameLabel:      "fn-name",

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
@@ -318,6 +318,7 @@ const (
 	FunctionResourceLabel                = "serverless.kyma-project.io/resource"
 	FunctionResourceLabelDeploymentValue = "deployment"
 	FunctionResourceLabelUserValue       = "user"
+	PodAppNameLabel                      = "app.kubernetes.io/name"
 )
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not set resource attribute SERVICE_NAME explicitly in function runtimes
- Add `app.kubernetes.io/name` label to function runtime pods

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/474#issuecomment-1862784363
Depends on https://github.com/kyma-project/telemetry-manager/issues/565