### PR TITLE
move baseDir and reference validations to x-kubernetes-validations

### DIFF
--- a/components/serverless/config/crd/bases/serverless.kyma-project.io_functions.yaml
+++ b/components/serverless/config/crd/bases/serverless.kyma-project.io_functions.yaml
@@ -405,6 +405,12 @@ spec:
                     required:
                     - url
                     type: object
+                    x-kubernetes-validations:
+                    - message: BaseDir is required and cannot be empty
+                      rule: has(self.baseDir) && (self.baseDir.trim().size() != 0)
+                    - message: Reference is required and cannot be empty
+                      rule: has(self.reference) && (self.reference.trim().size() !=
+                        0)
                   inline:
                     description: Defines the Function as the inline Function. Can't
                       be used together with **GitRepository**.

--- a/components/serverless/internal/webhook/validating_webhook_test.go
+++ b/components/serverless/internal/webhook/validating_webhook_test.go
@@ -147,12 +147,12 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 								},
 								"spec": {
 									"source": {
-                                        "gitRepository": {
-                                            "auth": {
+										"gitRepository": {
+											"auth": {
 												"type": "invalid"
 											}
-                                        }
-                                    }
+										}
+									}
 								}   
 							}`),
 						},

--- a/components/serverless/internal/webhook/validating_webhook_test.go
+++ b/components/serverless/internal/webhook/validating_webhook_test.go
@@ -147,7 +147,11 @@ func TestValidatingWebHook_Handle(t *testing.T) {
 								},
 								"spec": {
 									"source": {
-                                        "gitRepository": {}
+                                        "gitRepository": {
+                                            "auth": {
+												"type": "invalid"
+											}
+                                        }
                                     }
 								}   
 							}`),

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
@@ -71,6 +71,8 @@ type GitRepositorySource struct {
 	// +optional
 	Auth *RepositoryAuth `json:"auth,omitempty"`
 
+	// +kubebuilder:validation:XValidation:message="BaseDir is required and cannot be empty",rule="has(self.baseDir) && (self.baseDir.trim().size() != 0)"
+	// +kubebuilder:validation:XValidation:message="Reference is required and cannot be empty",rule="has(self.reference) && (self.reference.trim().size() != 0)"
 	Repository `json:",inline"`
 }
 

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation.go
@@ -85,12 +85,9 @@ func (spec *FunctionSpec) validateGitRepoURL(_ *ValidationConfig) error {
 
 func (spec *FunctionSpec) gitAuthValidations() []validationFunction {
 	if spec.Source.GitRepository.Auth == nil {
-		return []validationFunction{
-			spec.validateRepository,
-		}
+		return []validationFunction{}
 	}
 	return []validationFunction{
-		spec.validateRepository,
 		spec.validateGitAuthType,
 		spec.validateGitAuthSecretName,
 		spec.validateGitRepoURL,
@@ -113,18 +110,6 @@ func (spec *FunctionSpec) validateGitAuthType(_ *ValidationConfig) error {
 	default:
 		return ErrInvalidGitRepositoryAuthType
 	}
-}
-
-type property struct {
-	name  string
-	value string
-}
-
-func (spec *FunctionSpec) validateRepository(_ *ValidationConfig) error {
-	return validateIfMissingFields([]property{
-		{name: "spec.source.gitRepository.baseDir", value: spec.Source.GitRepository.BaseDir},
-		{name: "spec.source.gitRepository.reference", value: spec.Source.GitRepository.Reference},
-	}...)
 }
 
 func urlIsSSH(repoURL string) bool {

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_validation_test.go
@@ -179,50 +179,6 @@ func TestFunctionSpec_validateResources(t *testing.T) {
 			},
 			expectedError: gomega.BeNil(),
 		},
-		"Should return errors OK if reference and baseDir is missing": {
-			givenFunc: Function{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-				Spec: FunctionSpec{
-					Source: Source{
-						GitRepository: &GitRepositorySource{
-							URL: "testme",
-						},
-					},
-					ResourceConfiguration: &ResourceConfiguration{
-						Function: &ResourceRequirements{
-							Resources: &corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
-								},
-							},
-						},
-						Build: &ResourceRequirements{
-							Resources: &corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("200Mi"),
-								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("200Mi"),
-								},
-							},
-						},
-					},
-					Runtime: NodeJs18,
-				},
-			},
-			specifiedExpectedError: gomega.And(
-				gomega.ContainSubstring("spec.source.gitRepository.reference"),
-				gomega.ContainSubstring("spec.source.gitRepository.baseDir"),
-			),
-			expectedError: gomega.HaveOccurred(),
-		},
 		"Should validate without error Resources and Profile occurring at once in ResourceConfiguration.Function/Build": {
 			givenFunc: Function{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_x_validation_test.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_x_validation_test.go
@@ -345,7 +345,13 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 				Spec: serverlessv1alpha2.FunctionSpec{
 					Runtime: serverlessv1alpha2.Python39,
 					Source: serverlessv1alpha2.Source{
-						GitRepository: &serverlessv1alpha2.GitRepositorySource{}},
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "base-dir",
+								Reference: "ref",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -355,7 +361,7 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 				Spec: serverlessv1alpha2.FunctionSpec{
 					Runtime: serverlessv1alpha2.Python39,
 					Source: serverlessv1alpha2.Source{
-						GitRepository: &serverlessv1alpha2.GitRepositorySource{}},
+						Inline: &serverlessv1alpha2.InlineSource{Source: "abc"}},
 					Labels: map[string]string{
 						strings.Repeat("a", 63): "test",
 					},
@@ -368,7 +374,7 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 				Spec: serverlessv1alpha2.FunctionSpec{
 					Runtime: serverlessv1alpha2.Python39,
 					Source: serverlessv1alpha2.Source{
-						GitRepository: &serverlessv1alpha2.GitRepositorySource{}},
+						Inline: &serverlessv1alpha2.InlineSource{Source: "abc"}},
 					SecretMounts: []serverlessv1alpha2.SecretMount{{MountPath: "/path", SecretName: "secret-name"}},
 				},
 			},
@@ -818,6 +824,44 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedErrMsg: "should be at least 1 chars long",
 			fieldPath:      "spec.source.inline.source",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Git source has empty BaseDir": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python39,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "   ",
+								Reference: "ref",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "BaseDir is required and cannot be empty",
+			fieldPath:      "spec.source.gitRepository",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Git source has empty Reference": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python39,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "   ",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "Reference is required and cannot be empty",
+			fieldPath:      "spec.source.gitRepository",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
 	}

--- a/components/serverless/pkg/apis/serverless/v1alpha2/validation_helpers.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/validation_helpers.go
@@ -2,7 +2,6 @@ package v1alpha2
 
 import (
 	"fmt"
-	"strings"
 )
 
 func returnAllErrs(msg string, allErrs []string) error {
@@ -15,16 +14,4 @@ func returnAllErrs(msg string, allErrs []string) error {
 	}
 
 	return fmt.Errorf("%v", allErrs)
-}
-
-func validateIfMissingFields(properties ...property) error {
-	var allErrs []string
-	for _, item := range properties {
-		if strings.TrimSpace(item.value) != "" {
-			continue
-		}
-		allErrs = append(allErrs, fmt.Sprintf("%s is required", item.name))
-	}
-
-	return returnAllErrs("missing required fields", allErrs)
 }

--- a/config/serverless/templates/crds.yaml
+++ b/config/serverless/templates/crds.yaml
@@ -404,6 +404,12 @@ spec:
                     required:
                     - url
                     type: object
+                    x-kubernetes-validations:
+                    - message: BaseDir is required and cannot be empty
+                      rule: has(self.baseDir) && (self.baseDir.trim().size() != 0)
+                    - message: Reference is required and cannot be empty
+                      rule: has(self.reference) && (self.reference.trim().size() !=
+                        0)
                   inline:
                     description: Defines the Function as the inline Function. Can't
                       be used together with **GitRepository**.


### PR DESCRIPTION
**Description**

Move baseDir and reference validations from webhook to x-kubernetes-validations.

**Related issue(s)**
See also #250 