### PR TITLE
disable webhooks

### DIFF
--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -313,5 +313,5 @@ docker-registry:
   rollme: "{{ randAlphaNum 5}}"
   registryHTTPSecret: "{{ randAlphaNum 16 | b64enc }}"
 webhook:
-  enabled: true
+  enabled: false
   fullnameOverride: "serverless-webhook"


### PR DESCRIPTION
**Description**

Disable webhooks.
Defaulting webhook already was empty.
Validation webhook functionality was moved to kubernetes validations and to controller.

**Related issue(s)**
See also #250