### PR TITLE
Remove secrets and configmaps from the cache

### DIFF
--- a/components/operator/main.go
+++ b/components/operator/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	corev1 "k8s.io/api/core/v1"
 	"os"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	uberzapcore "go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/components/operator/main.go
+++ b/components/operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"time"
 
@@ -100,6 +101,10 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		SyncPeriod:             &syncPeriod,
+		ClientDisableCacheFor: []ctrlclient.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 		// TODO: use our own logger - now eventing use logger with different message format
 	})
 	if err != nil {

--- a/components/serverless/cmd/manager/main.go
+++ b/components/serverless/cmd/manager/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 	"os"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/go-logr/zapr"
@@ -108,6 +110,10 @@ func main() {
 		LeaderElectionID:       config.LeaderElectionID,
 		Port:                   config.SecretMutatingWebhookPort,
 		HealthProbeBindAddress: config.Healthz.Address,
+		ClientDisableCacheFor: []ctrlclient.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize controller manager")

--- a/components/serverless/cmd/manager/main.go
+++ b/components/serverless/cmd/manager/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"os"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/go-logr/zapr"
@@ -19,10 +17,13 @@ import (
 	"github.com/vrischmann/envconfig"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/components/serverless/cmd/webhook/main.go
+++ b/components/serverless/cmd/webhook/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/zapr"
 	fileconfig "github.com/kyma-project/kyma/components/function-controller/internal/config"
@@ -89,6 +90,10 @@ func main() {
 		Port:               cfg.Port,
 		MetricsBindAddress: ":9090",
 		Logger:             logrZap,
+		ClientDisableCacheFor: []ctrlclient.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 	})
 	if err != nil {
 		logWithCtx.Error(err, "failed to setup controller-manager")

--- a/components/serverless/cmd/webhook/main.go
+++ b/components/serverless/cmd/webhook/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/zapr"
 	fileconfig "github.com/kyma-project/kyma/components/function-controller/internal/config"
@@ -21,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Exclude any arbitrary secrets and config maps from being auto-loaded to controllers cache

Changes proposed in this pull request:

- Remove `secrets` and `configmaps` from the cache from `operator`
- Remove `secrets` and `configmaps` from the cache from `controller`
- Remove `secrets` and `configmaps` from the cache from `webhook`
-
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#506