### PR TITLE
Validate scaleConfig boundaries

### DIFF
--- a/components/serverless/config/crd/bases/serverless.kyma-project.io_functions.yaml
+++ b/components/serverless/config/crd/bases/serverless.kyma-project.io_functions.yaml
@@ -334,6 +334,9 @@ spec:
                 - maxReplicas
                 - minReplicas
                 type: object
+                x-kubernetes-validations:
+                - message: minReplicas should be less than or equal maxReplicas
+                  rule: self.minReplicas <= self.maxReplicas
               secretMounts:
                 description: Specifies Secrets to mount into the Function's container
                   filesystem.

--- a/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/function_types.go
@@ -194,6 +194,7 @@ type FunctionSpec struct {
 	// When it is configured, a HorizontalPodAutoscaler will be deployed and will control the **Replicas** field
 	// to scale the Function based on the CPU utilisation.
 	// +optional
+	// +kubebuilder:validation:XValidation:message="minReplicas should be less than or equal maxReplicas",rule="self.minReplicas <= self.maxReplicas"
 	ScaleConfig *ScaleConfig `json:"scaleConfig,omitempty"`
 
 	// Defines the exact number of Function's Pods to run at a time.

--- a/config/serverless/templates/crds.yaml
+++ b/config/serverless/templates/crds.yaml
@@ -333,6 +333,9 @@ spec:
                 - maxReplicas
                 - minReplicas
                 type: object
+                x-kubernetes-validations:
+                - message: minReplicas should be less than or equal maxReplicas
+                  rule: self.minReplicas <= self.maxReplicas
               secretMounts:
                 description: Specifies Secrets to mount into the Function's container
                   filesystem.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- validate that `scaleConfig.maxRelicas` is greater or equal `scaleConfig.minRelicas`

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/250