### PR TITLE
Migrate lint operator job

### DIFF
--- a/.github/workflows/operator-verify.yaml
+++ b/.github/workflows/operator-verify.yaml
@@ -13,9 +13,22 @@ on:
       - synchronize
       - ready_for_review
       - converted_to_draft
+
 jobs:
+  # pre-serverless-operator-lint
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: golangci/golangci-lint-action@v3
+        continue-on-error: true
+        with:
+          version: latest
+          working-directory: 'components/operator'
+
   # pre-serverless-operator-unit-tests
-  serverless-operator-unit-tests:
+  unit-tests:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +37,7 @@ jobs:
         run: make -C components/operator test
 
   # pre-serverless-operator-verify, post-serverless-operator-verify
-  serverless-operator-verify:
+  integration-tests:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/operator-verify.yaml
+++ b/.github/workflows/operator-verify.yaml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v3
-        continue-on-error: true
         with:
           version: latest
           working-directory: 'components/operator'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- migrate the `pre-serverless-operator-lint` ([link](https://github.com/kyma-project/test-infra/blob/main/templates/data/serverless.yaml#L537)) job to GitHub action

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/test-infra/issues/9463