### PR TITLE
Enable Dependabot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,13 +78,3 @@ updates:
     commit-message:
       prefix: "pip-python39"
       include: "scope"
-  - package-ecosystem: "pip"
-    directory: "/tests/serverless-bench"
-    labels:
-      - "area/dependency"
-      - "kind/chore"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "pip-test"
-      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,16 +57,6 @@ updates:
     commit-message:
       prefix: "gitserver"
       include: "scope"
-  - package-ecosystem: "docker"
-    directory: "/tests/serverless-bench"
-    labels:
-      - "area/dependency"
-      - "kind/chore"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "serverless-bench"
-      include: "scope"
 
   - package-ecosystem: "pip"
     directory: "/components/runtimes/python39/kubeless"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,24 @@ updates:
     commit-message:
       prefix: "serverless-bench"
       include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/components/runtimes/python39/kubeless"
+    labels:
+      - "area/dependency"
+      - "kind/chore"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "pip-python39"
+      include: "scope"
+  - package-ecosystem: "pip"
+    directory: "/tests/serverless-bench"
+    labels:
+      - "area/dependency"
+      - "kind/chore"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "pip-test"
+      include: "scope"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Enable Dependabot for Python dependencies:
    - `components/runtimes/python39/kubeless`
    -  `/tests/serverless-bench`
    - excluding `examples/python-text2img`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #540