### PR TITLE
Remove redundant integration test

### DIFF
--- a/.github/workflows/serverless-verify.yaml
+++ b/.github/workflows/serverless-verify.yaml
@@ -38,7 +38,7 @@ jobs:
         run: make -C components/serverless test
   
   #pre-serverless-integration-k3s
-  integration-test:
+  contract-integration-test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +58,7 @@ jobs:
         env:
           IMG: europe-docker.pkg.dev/kyma-project/dev/serverless-operator:PR-${{ github.event.number }}
       - name: run tests
-        run: make -C tests/serverless serverless-integration serverless-contract-tests
+        run: make -C tests/serverless serverless-contract-tests
   
   #pre-serverless-git-auth-integration-k3s
   git-auth-integration-test:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- remove the `serverless-integration` test case because it's used in the `operator-verify` workflow 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/682