### PR TITLE
Retry GET request to function

### DIFF
--- a/tests/serverless/internal/resources/function/steps.go
+++ b/tests/serverless/internal/resources/function/steps.go
@@ -34,7 +34,7 @@ func (f newFunction) Run() error {
 	}
 
 	f.log.Infof("Function Created, Waiting for ready status")
-	return errors.Wrapf(f.fn.WaitForStatusRunning(), "while waiting for function: %s, to be ready:", f.name)
+	return errors.Wrapf(f.fn.WaitForStatusRunning(), "while waiting for function: %s, to be ready:", f.fn.function.GetName())
 }
 
 func (f newFunction) Cleanup() error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add retry when getting CloudEvent from the function - to cover the case when the GET request reaches publisher-proxy before publishing it
- improve error wrap message - print the function's name, not the step's name

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/600#issue-2086038042