### PR TITLE
Smart function presets defaulting

### DIFF
--- a/components/operator/controllers/serverless_controller_rbac.go
+++ b/components/operator/controllers/serverless_controller_rbac.go
@@ -5,6 +5,7 @@ package controllers
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups="",resources=services;secrets;serviceaccounts;configmaps,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete;deletecollection
 
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=list

--- a/components/operator/internal/state/controller_configuration.go
+++ b/components/operator/internal/state/controller_configuration.go
@@ -4,12 +4,24 @@ import (
 	"context"
 
 	"github.com/kyma-project/serverless/components/operator/api/v1alpha1"
-	"k8s.io/client-go/tools/record"
+	corev1 "k8s.io/api/core/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func sFnControllerConfiguration(_ context.Context, r *reconciler, s *systemState) (stateFn, *controllerruntime.Result, error) {
-	updateControllerConfigurationStatus(r.k8s, &s.instance)
+const (
+	slowBuildPreset   = "slow"
+	slowRuntimePreset = "XS"
+	fastBuildPreset   = "fast"
+	fastRuntimePreset = "L"
+)
+
+func sFnControllerConfiguration(ctx context.Context, r *reconciler, s *systemState) (stateFn, *controllerruntime.Result, error) {
+	err := updateControllerConfigurationStatus(ctx, r, &s.instance)
+	if err != nil {
+		return stopWithEventualError(err)
+	}
+
 	configureControllerConfigurationFlags(s)
 
 	s.setState(v1alpha1.StateProcessing)
@@ -22,22 +34,34 @@ func sFnControllerConfiguration(_ context.Context, r *reconciler, s *systemState
 	return nextState(sFnApplyResources)
 }
 
-func updateControllerConfigurationStatus(eventRecorder record.EventRecorder, instance *v1alpha1.Serverless) {
-	spec := instance.Spec
-
-	fields := fieldsToUpdate{
-		{spec.TargetCPUUtilizationPercentage, &instance.Status.CPUUtilizationPercentage, "CPU utilization"},
-		{spec.FunctionRequeueDuration, &instance.Status.RequeueDuration, "Function requeue duration"},
-		{spec.FunctionBuildExecutorArgs, &instance.Status.BuildExecutorArgs, "Function build executor args"},
-		{spec.FunctionBuildMaxSimultaneousJobs, &instance.Status.BuildMaxSimultaneousJobs, "Max number of simultaneous jobs"},
-		{spec.HealthzLivenessTimeout, &instance.Status.HealthzLivenessTimeout, "Duration of health check"},
-		{spec.FunctionRequestBodyLimitMb, &instance.Status.RequestBodyLimitMb, "Max size of request body"},
-		{spec.FunctionTimeoutSec, &instance.Status.TimeoutSec, "Timeout"},
-		{spec.DefaultBuildJobPreset, &instance.Status.DefaultBuildJobPreset, "Default build job preset"},
-		{spec.DefaultRuntimePodPreset, &instance.Status.DefaultRuntimePodPreset, "Default runtime pod preset"},
+func updateControllerConfigurationStatus(ctx context.Context, r *reconciler, instance *v1alpha1.Serverless) error {
+	nodesLen, err := getNodesLen(ctx, r.client)
+	if err != nil {
+		return err
 	}
 
-	updateStatusFields(eventRecorder, instance, fields)
+	defaultBuildPreset := slowBuildPreset
+	defaultRuntimePreset := slowRuntimePreset
+	if nodesLen > 2 {
+		defaultBuildPreset = fastBuildPreset
+		defaultRuntimePreset = fastRuntimePreset
+	}
+
+	spec := instance.Spec
+	fields := fieldsToUpdate{
+		{spec.TargetCPUUtilizationPercentage, &instance.Status.CPUUtilizationPercentage, "CPU utilization", ""},
+		{spec.FunctionRequeueDuration, &instance.Status.RequeueDuration, "Function requeue duration", ""},
+		{spec.FunctionBuildExecutorArgs, &instance.Status.BuildExecutorArgs, "Function build executor args", ""},
+		{spec.FunctionBuildMaxSimultaneousJobs, &instance.Status.BuildMaxSimultaneousJobs, "Max number of simultaneous jobs", ""},
+		{spec.HealthzLivenessTimeout, &instance.Status.HealthzLivenessTimeout, "Duration of health check", ""},
+		{spec.FunctionRequestBodyLimitMb, &instance.Status.RequestBodyLimitMb, "Max size of request body", ""},
+		{spec.FunctionTimeoutSec, &instance.Status.TimeoutSec, "Timeout", ""},
+		{spec.DefaultBuildJobPreset, &instance.Status.DefaultBuildJobPreset, "Default build job preset", defaultBuildPreset},
+		{spec.DefaultRuntimePodPreset, &instance.Status.DefaultRuntimePodPreset, "Default runtime pod preset", defaultRuntimePreset},
+	}
+
+	updateStatusFields(r.k8s, instance, fields)
+	return nil
 }
 
 func configureControllerConfigurationFlags(s *systemState) {
@@ -55,4 +79,14 @@ func configureControllerConfigurationFlags(s *systemState) {
 			s.instance.Status.DefaultBuildJobPreset,
 			s.instance.Status.DefaultRuntimePodPreset,
 		)
+}
+
+func getNodesLen(ctx context.Context, c client.Client) (int, error) {
+	nodeList := corev1.NodeList{}
+	err := c.List(ctx, &nodeList)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(nodeList.Items), nil
 }

--- a/components/operator/internal/state/controller_configuration_test.go
+++ b/components/operator/internal/state/controller_configuration_test.go
@@ -97,8 +97,8 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		requireEqualFunc(t, sFnApplyResources, next)
 
 		status := s.instance.Status
-		require.Equal(t, slowBuildPreset, status.DefaultBuildJobPreset)
-		require.Equal(t, slowRuntimePreset, status.DefaultRuntimePodPreset)
+		require.Equal(t, fastBuildPreset, status.DefaultBuildJobPreset)
+		require.Equal(t, fastRuntimePreset, status.DefaultRuntimePodPreset)
 
 		require.Equal(t, v1alpha1.StateProcessing, status.State)
 		requireContainsCondition(t, status,

--- a/components/operator/internal/state/controller_configuration_test.go
+++ b/components/operator/internal/state/controller_configuration_test.go
@@ -10,16 +10,113 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	cpuUtilizationTest         = "test-CPU-utilization-percentage"
+	requeueDurationTest        = "test-requeue-duration"
+	executorArgsTest           = "test-build-executor-args"
+	maxSimultaneousJobsTest    = "test-max-simultaneous-jobs"
+	healthzLivenessTimeoutTest = "test-healthz-liveness-timeout"
+	requestBodyLimitMbTest     = "test-request-body-limit-mb"
+	timeoutSecTest             = "test-timeout-sec"
+	buildJobPresetTest         = "test=default-build-job-preset"
+	runtimePodPresetTest       = "test-default-runtime-pod-preset"
+)
+
 func Test_sFnControllerConfiguration(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
 	configurationReadyMsg := "Configuration ready"
+
+	t.Run("update status with slow defaults", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Spec: v1alpha1.ServerlessSpec{},
+			},
+			flagsBuilder: chart.NewFlagsBuilder(),
+		}
+
+		c := fake.NewClientBuilder().WithObjects(
+			fixTestNode("node-1"),
+			fixTestNode("node-2"),
+		).Build()
+		eventRecorder := record.NewFakeRecorder(2)
+		r := &reconciler{log: zap.NewNop().Sugar(), k8s: k8s{client: c, EventRecorder: eventRecorder}}
+		next, result, err := sFnControllerConfiguration(context.TODO(), r, s)
+		require.Nil(t, err)
+		require.Nil(t, result)
+		requireEqualFunc(t, sFnApplyResources, next)
+
+		status := s.instance.Status
+		require.Equal(t, slowBuildPreset, status.DefaultBuildJobPreset)
+		require.Equal(t, slowRuntimePreset, status.DefaultRuntimePodPreset)
+
+		require.Equal(t, v1alpha1.StateProcessing, status.State)
+		requireContainsCondition(t, status,
+			v1alpha1.ConditionTypeConfigured,
+			metav1.ConditionTrue,
+			v1alpha1.ConditionReasonConfigured,
+			configurationReadyMsg,
+		)
+
+		expectedEvents := []string{
+			"Normal Configuration Default build job preset set from '' to 'slow'",
+			"Normal Configuration Default runtime pod preset set from '' to 'XS'",
+		}
+
+		for _, expectedEvent := range expectedEvents {
+			require.Equal(t, expectedEvent, <-eventRecorder.Events)
+		}
+	})
+
+	t.Run("update slow default to fast ones", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Spec: v1alpha1.ServerlessSpec{},
+				Status: v1alpha1.ServerlessStatus{
+					DefaultBuildJobPreset:   slowBuildPreset,
+					DefaultRuntimePodPreset: slowRuntimePreset,
+				},
+			},
+			flagsBuilder: chart.NewFlagsBuilder(),
+		}
+
+		c := fake.NewClientBuilder().WithObjects(
+			fixTestNode("node-1"),
+			fixTestNode("node-2"),
+			fixTestNode("node-3"),
+			fixTestNode("node-4"),
+		).Build()
+		eventRecorder := record.NewFakeRecorder(2)
+		r := &reconciler{log: zap.NewNop().Sugar(), k8s: k8s{client: c, EventRecorder: eventRecorder}}
+		next, result, err := sFnControllerConfiguration(context.TODO(), r, s)
+		require.Nil(t, err)
+		require.Nil(t, result)
+		requireEqualFunc(t, sFnApplyResources, next)
+
+		status := s.instance.Status
+		require.Equal(t, slowBuildPreset, status.DefaultBuildJobPreset)
+		require.Equal(t, slowRuntimePreset, status.DefaultRuntimePodPreset)
+
+		require.Equal(t, v1alpha1.StateProcessing, status.State)
+		requireContainsCondition(t, status,
+			v1alpha1.ConditionTypeConfigured,
+			metav1.ConditionTrue,
+			v1alpha1.ConditionReasonConfigured,
+			configurationReadyMsg,
+		)
+
+		expectedEvents := []string{
+			"Normal Configuration Default build job preset set from 'slow' to 'fast'",
+			"Normal Configuration Default runtime pod preset set from 'XS' to 'L'",
+		}
+
+		for _, expectedEvent := range expectedEvents {
+			require.Equal(t, expectedEvent, <-eventRecorder.Events)
+		}
+	})
 
 	t.Run("update status additional configuration overrides", func(t *testing.T) {
 		s := &systemState{
@@ -32,14 +129,14 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 					HealthzLivenessTimeout:           healthzLivenessTimeoutTest,
 					FunctionRequestBodyLimitMb:       requestBodyLimitMbTest,
 					FunctionTimeoutSec:               timeoutSecTest,
-					DefaultBuildJobPreset:            defaultBuildJobPresetTest,
-					DefaultRuntimePodPreset:          defaultRuntimePodPresetTest,
+					DefaultBuildJobPreset:            buildJobPresetTest,
+					DefaultRuntimePodPreset:          runtimePodPresetTest,
 				},
 			},
 			flagsBuilder: chart.NewFlagsBuilder(),
 		}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		c := fake.NewClientBuilder().Build()
 		eventRecorder := record.NewFakeRecorder(10)
 		r := &reconciler{log: zap.NewNop().Sugar(), k8s: k8s{client: c, EventRecorder: eventRecorder}}
 		next, result, err := sFnControllerConfiguration(context.TODO(), r, s)
@@ -55,8 +152,8 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		require.Equal(t, healthzLivenessTimeoutTest, status.HealthzLivenessTimeout)
 		require.Equal(t, requestBodyLimitMbTest, status.RequestBodyLimitMb)
 		require.Equal(t, timeoutSecTest, status.TimeoutSec)
-		require.Equal(t, defaultBuildJobPresetTest, status.DefaultBuildJobPreset)
-		require.Equal(t, defaultRuntimePodPresetTest, status.DefaultRuntimePodPreset)
+		require.Equal(t, buildJobPresetTest, status.DefaultBuildJobPreset)
+		require.Equal(t, runtimePodPresetTest, status.DefaultRuntimePodPreset)
 
 		require.Equal(t, v1alpha1.StateProcessing, status.State)
 		requireContainsCondition(t, status,
@@ -125,7 +222,8 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		r := &reconciler{
 			log: zap.NewNop().Sugar(),
 			k8s: k8s{
-				client: fake.NewClientBuilder().WithObjects(secret).Build(),
+				client:        fake.NewClientBuilder().WithObjects(secret).Build(),
+				EventRecorder: record.NewFakeRecorder(2),
 			},
 		}
 
@@ -140,4 +238,12 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 			configurationReadyMsg)
 		require.Equal(t, v1alpha1.StateProcessing, s.instance.Status.State)
 	})
+}
+
+func fixTestNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
 }

--- a/components/operator/internal/state/optional_dependencies.go
+++ b/components/operator/internal/state/optional_dependencies.go
@@ -56,8 +56,8 @@ func getEventingURL(spec v1alpha1.ServerlessSpec) string {
 
 func updateOptionalDependenciesStatus(eventRecorder record.EventRecorder, instance *v1alpha1.Serverless, eventingURL, tracingURL string) {
 	fields := fieldsToUpdate{
-		{eventingURL, &instance.Status.EventingEndpoint, "Eventing endpoint"},
-		{tracingURL, &instance.Status.TracingEndpoint, "Tracing endpoint"},
+		{eventingURL, &instance.Status.EventingEndpoint, "Eventing endpoint", ""},
+		{tracingURL, &instance.Status.TracingEndpoint, "Tracing endpoint", ""},
 	}
 
 	updateStatusFields(eventRecorder, instance, fields)

--- a/components/operator/internal/state/optional_dependencies_test.go
+++ b/components/operator/internal/state/optional_dependencies_test.go
@@ -17,18 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const (
-	cpuUtilizationTest          = "test-CPU-utilization-percentage"
-	requeueDurationTest         = "test-requeue-duration"
-	executorArgsTest            = "test-build-executor-args"
-	maxSimultaneousJobsTest     = "test-max-simultaneous-jobs"
-	healthzLivenessTimeoutTest  = "test-healthz-liveness-timeout"
-	requestBodyLimitMbTest      = "test-request-body-limit-mb"
-	timeoutSecTest              = "test-timeout-sec"
-	defaultBuildJobPresetTest   = "test=default-build-job-preset"
-	defaultRuntimePodPresetTest = "test-default-runtime-pod-preset"
-)
-
 func Test_sFnOptionalDependencies(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/components/operator/internal/state/state.go
+++ b/components/operator/internal/state/state.go
@@ -1,10 +1,10 @@
 package state
 
 import (
-	"github.com/kyma-project/serverless/components/operator/api/v1alpha1"
-	"k8s.io/client-go/tools/record"
 	"time"
 
+	"github.com/kyma-project/serverless/components/operator/api/v1alpha1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -39,13 +39,19 @@ func requeueAfter(duration time.Duration) (stateFn, *ctrl.Result, error) {
 }
 
 type fieldsToUpdate []struct {
-	specField   string
-	statusField *string
-	fieldName   string
+	specField    string
+	statusField  *string
+	fieldName    string
+	defaultValue string
 }
 
 func updateStatusFields(eventRecorder record.EventRecorder, instance *v1alpha1.Serverless, fields fieldsToUpdate) {
 	for _, field := range fields {
+		// set default value if spec field is empty
+		if field.specField == "" {
+			field.specField = field.defaultValue
+		}
+
 		if field.specField != *field.statusField {
 			oldStatusValue := *field.statusField
 			*field.statusField = field.specField

--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -47,6 +47,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add functionality to setup the `runtimePodPreset` and the `buildPreset` defaults based on the Nodes number

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/675