### PR TITLE
changed serverless status when duplicated to warning instead of error

### DIFF
--- a/components/operator/internal/state/served_filter.go
+++ b/components/operator/internal/state/served_filter.go
@@ -37,8 +37,9 @@ func setServed(servedServerless *v1alpha1.Serverless, s *systemState) error {
 	}
 
 	s.setServed(v1alpha1.ServedFalse)
-	s.setState(v1alpha1.StateError)
-	err := fmt.Errorf("only one instance of Serverless is allowed (current served instance: %s/%s)",
+	s.setState(v1alpha1.StateWarning)
+	err := fmt.Errorf(
+		"Only one instance of Serverless is allowed (current served instance: %s/%s). This Serverless CR is redundant. Remove it to fix the problem.",
 		servedServerless.GetNamespace(), servedServerless.GetName())
 	s.instance.UpdateConditionFalse(
 		v1alpha1.ConditionTypeConfigured,

--- a/components/operator/internal/state/served_filter_test.go
+++ b/components/operator/internal/state/served_filter_test.go
@@ -106,18 +106,19 @@ func Test_sFnServedFilter(t *testing.T) {
 
 		nextFn, result, err := sFnServedFilter(context.TODO(), r, s)
 
-		require.EqualError(t, err, "only one instance of Serverless is allowed (current served instance: serverless-test/test-2)")
+		expectedErrorMessage := "Only one instance of Serverless is allowed (current served instance: serverless-test/test-2). This Serverless CR is redundant. Remove it to fix the problem."
+		require.EqualError(t, err, expectedErrorMessage)
 		require.Nil(t, result)
 		require.Nil(t, nextFn)
 		require.Equal(t, v1alpha1.ServedFalse, s.instance.Status.Served)
 
 		status := s.instance.Status
-		require.Equal(t, v1alpha1.StateError, status.State)
+		require.Equal(t, v1alpha1.StateWarning, status.State)
 		requireContainsCondition(t, status,
 			v1alpha1.ConditionTypeConfigured,
 			metav1.ConditionFalse,
 			v1alpha1.ConditionReasonServerlessDuplicated,
-			"only one instance of Serverless is allowed (current served instance: serverless-test/test-2)",
+			expectedErrorMessage,
 		)
 	})
 }


### PR DESCRIPTION
**Description**

Changed serverless status when duplicated to warning instead of error

**Related issue(s)**
See also: #723 