### PR TITLE
Handle /favicon.ico requests in python runtimes the same as in case of nodejs

### DIFF
--- a/components/runtimes/python39/kubeless/kubeless.py
+++ b/components/runtimes/python39/kubeless/kubeless.py
@@ -65,6 +65,10 @@ def func_with_context(e, function_context):
                 return e
 
 
+@app.get('/favicon.ico')
+def favicon():
+    return bottle.HTTPResponse(status=204)
+
 @app.get('/healthz')
 def healthz():
     return 'OK'


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not execute function logic when browser requests `/favicon.ico`

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/5113