### PR TITLE
Makefile refactor images replacing

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Bump values.yaml
         run: |
-          make -C components/operator/hack/ci replace-function-chart-images
+          make -C components/operator/hack/ci replace-all-serverless-chart-images
         env:
           IMG_DIRECTORY: "prod"
           IMG_VERSION: ${{ github.event.inputs.name }}

--- a/components/operator/Dockerfile
+++ b/components/operator/Dockerfile
@@ -41,7 +41,7 @@ COPY components/operator/hack components/operator/hack
 COPY config/serverless config/serverless
 COPY hack/ hack/
 
-RUN if [[ "dev" = "$PURPOSE" ]] ; then make -C components/operator/hack/ci replace-function-chart-images ; fi
+RUN if [[ "dev" = "$PURPOSE" ]] ; then make -C components/operator/hack/ci replace-all-serverless-chart-images ; fi
 RUN if [[ "local" = "$PURPOSE" ]] ; then make -C components/operator/hack/ci replace-only-main-chart-images ; fi
 # do nothing (keep unchanged versions) for "release"
 

--- a/components/operator/hack/ci/Makefile
+++ b/components/operator/hack/ci/Makefile
@@ -13,8 +13,8 @@ replace-only-main-chart-images: check-img-envs
 	yq '.global.images' ${PROJECT_ROOT}/config/serverless/values.yaml
 	@echo "==== End of Local Changes ===="
 
-.PHONY: replace-function-chart-images
-replace-function-chart-images: check-img-envs
+.PHONY: replace-all-serverless-chart-images
+replace-all-serverless-chart-images: check-img-envs
 	yq -i "(.global.images[] | select(key == \"function_*\") | .directory) = \"${IMG_DIRECTORY}\"" ${PROJECT_ROOT}/config/serverless/values.yaml
 	yq -i "(.global.images[] | select(key == \"function_*\") | .version) = \"${IMG_VERSION}\"" ${PROJECT_ROOT}/config/serverless/values.yaml
 	@echo "==== Local Changes ===="

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -25,9 +25,9 @@ integration-test-on-cluster: ## Install serverless with default serverless-cr, r
 	make -C ${PROJECT_ROOT} remove-serverless
 
 .PHONY: git-auth-test-on-cluster
-git-auth-test-on-cluster: # Install serverless with default serverless-cr, run git auth integration and remove serverless-cr
+git-auth-test-on-cluster: ## Install serverless with default serverless-cr, run git auth integration and remove serverless-cr
 	make -C ${PROJECT_ROOT} install-serverless-main
-	cd ${TEST_ROOT} && make git-auth-integration
+	make -C ${TEST_ROOT} git-auth-integration
 	make -C ${PROJECT_ROOT} remove-serverless
 
 .PHONY: upgrade-test


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- small fixes and unification in hack/ci/Makefile
- rename target for replacing all serverless images

**Related issue(s)**
See also #679 