### PR TITLE
Add flag to ignore GCE creds helper creation for kaniko job

### DIFF
--- a/components/serverless/internal/controllers/serverless/system_state.go
+++ b/components/serverless/internal/controllers/serverless/system_state.go
@@ -260,6 +260,12 @@ func (s *systemState) buildJobExecutorContainer(cfg cfg, volumeMounts []corev1.V
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Env: []corev1.EnvVar{
 			{Name: "DOCKER_CONFIG", Value: "/docker/.docker/"},
+			// GOOGLE_APPLICATION_CREDENTIALS is set to file which does not exist to prevent GCE credential helper creation
+			// this is required because Kaniko does not work on clusters run on GKE with the default GCE ServiceAccount
+			// with bound bearer token to it. When such SA exists then Kaniko uses this token to pull any image
+			// from the pkg.dev registry - even public ones - which causes 401 UNAUTHORIZED status during runtime
+			// base pull because we store our runtime bases on the pkg.dev registry
+			{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/dev/null"},
 		},
 		SecurityContext: buildJobContainerSecurityContext(),
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- disable the GCR creds helper used to pull images described in the given Dockerfile. In our case, we always put there only public images (runtime bases) so we don't need such a helper. This helper can cause a really hard to debug issue when cluster owner defines the default GCE service account with the Bearer token -> in this case kaniko will use this SA token for pulling all images described in the Dockerfile. This can cause kaniko pod error with communicate `401 UNAUTHORIZED`
- from comment:
  ```
  // GOOGLE_APPLICATION_CREDENTIALS is set to file which does not exist to prevent GCE credential helper creation
  // this is required because Kaniko does not work on clusters run on GKE with the default GCE ServiceAccount
  // with bound bearer token to it. When such SA exists then Kaniko uses this token to pull any image
  // from the pkg.dev registry - even public ones - which causes 401 UNAUTHORIZED status during runtime
  // base pull because we store our runtime bases on the pkg.dev registry
  ```
