### PR TITLE
fix typo in makefile variable

### DIFF
--- a/hack/gardener.mk
+++ b/hack/gardener.mk
@@ -14,7 +14,7 @@ else
 GARDENER_K8S_VERSION=1.27.4
 endif
 #Overwrite default kyma cli gardenlinux version because it's not supported.
-GARDENR_LINUX_VERSION=gardenlinux:1312.3.0
+GARDENER_LINUX_VERSION=gardenlinux:1312.3.0
 
 .PHONY: provision-gardener
 provision-gardener: kyma ## Provision gardener cluster with latest k8s version


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix typo in makefile variable GARDENER_LINUX_VERSION

**Related issue(s)**
See also #679 