### PR TITLE
Do not keep orphaned replicaset fro function managed deployments

### DIFF
--- a/components/serverless/internal/controllers/serverless/deployment_test.go
+++ b/components/serverless/internal/controllers/serverless/deployment_test.go
@@ -1021,9 +1021,11 @@ func TestFunctionReconciler_isDeploymentReady(t *testing.T) {
 }
 
 func fixDeploymentWithReplicas(replicas int32) appsv1.Deployment {
+	zero := int32(0)
 	return appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			RevisionHistoryLimit: &zero,
+			Replicas:             &replicas,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{}},

--- a/components/serverless/internal/controllers/serverless/system_state.go
+++ b/components/serverless/internal/controllers/serverless/system_state.go
@@ -518,6 +518,7 @@ func (s *systemState) buildDeployment(cfg buildDeploymentArgs, resourceConfig Re
 	}
 	enrichPodSpecWithSecurityContext(&templateSpec, functionUser, functionUserGroup)
 
+	zero := int32(0)
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", s.instance.GetName()),
@@ -525,7 +526,8 @@ func (s *systemState) buildDeployment(cfg buildDeploymentArgs, resourceConfig Re
 			Labels:       s.functionLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: s.getReplicas(DefaultDeploymentReplicas),
+			RevisionHistoryLimit: &zero,
+			Replicas:             s.getReplicas(DefaultDeploymentReplicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: s.deploymentSelectorLabels(), // this has to match spec.template.objectmeta.Labels
 				// and also it has to be immutable


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Serverless managed deployments do not need the previous replica set revisions 
