### PR TITLE
chore: Bump nodejs runtimes base images

### DIFF
--- a/components/runtimes/nodejs/nodejs18/Dockerfile
+++ b/components/runtimes/nodejs/nodejs18/Dockerfile
@@ -1,5 +1,5 @@
-# image base on node:18.16.1-alpine3.17 (node:18.16.0, alpine:3.17.4)
-FROM node@sha256:56a82eb7c721b7e4c151366000a60d1f1b1ded51e55e8ff9cc106f603dfe6521
+# image base on node:18.20.1-alpine3.19
+FROM node@sha256:6d9d5269cbe4088803e9ef81da62ac481c063b60cadbe8e628bfcbb12296d901
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV

--- a/components/runtimes/nodejs/nodejs20/Dockerfile
+++ b/components/runtimes/nodejs/nodejs20/Dockerfile
@@ -1,5 +1,5 @@
-# image base on node:20.11.1-alpine3.19 (node:20.11.1, alpine:3.19.1)
-FROM node@sha256:c0a3badbd8a0a760de903e00cedbca94588e609299820557e72cba2a53dbaa2c
+# image base on node:20.12.1-alpine3.19
+FROM node@sha256:7e227295e96f5b00aa79555ae166f50610940d888fc2e321cf36304cbd17d7d6
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bring latest security patches for nodejs base images

