### PR TITLE
Warn if dead fields are used

### DIFF
--- a/components/operator/internal/state/controller_configuration.go
+++ b/components/operator/internal/state/controller_configuration.go
@@ -37,14 +37,13 @@ func sFnControllerConfiguration(ctx context.Context, r *reconciler, s *systemSta
 	return nextState(sFnApplyResources)
 }
 
-func warnAboutDeadFields(s *systemState) error {
+func warnAboutDeadFields(s *systemState) {
 	if s.instance.Spec.FunctionTimeoutSec != "" {
 		s.warningBuilder.With(functionTimeoutDepreciationMessage)
 	}
 	if s.instance.Spec.FunctionRequestBodyLimitMb != "" {
 		s.warningBuilder.With(functionRequestBodyLimitDepreciationMessage)
 	}
-	return nil
 }
 
 func updateControllerConfigurationStatus(ctx context.Context, r *reconciler, instance *v1alpha1.Serverless) error {

--- a/components/operator/internal/state/controller_configuration.go
+++ b/components/operator/internal/state/controller_configuration.go
@@ -14,6 +14,8 @@ const (
 	slowRuntimePreset = "XS"
 	fastBuildPreset   = "fast"
 	fastRuntimePreset = "L"
+	functionTimeoutDepreciationMessage = "spec.functionTimeoutSec is unused and will be removed. Remove it from your Serverless CR."
+	functionRequestBodyLimitDepreciationMessage = "spec.functionRequestBodyLimitMb is unused and will be removed. Remove it from your Serverless CR."
 )
 
 func sFnControllerConfiguration(ctx context.Context, r *reconciler, s *systemState) (stateFn, *controllerruntime.Result, error) {
@@ -23,6 +25,7 @@ func sFnControllerConfiguration(ctx context.Context, r *reconciler, s *systemSta
 	}
 
 	configureControllerConfigurationFlags(s)
+	warnAboutDeadFields(s)
 
 	s.setState(v1alpha1.StateProcessing)
 	s.instance.UpdateConditionTrue(
@@ -32,6 +35,16 @@ func sFnControllerConfiguration(ctx context.Context, r *reconciler, s *systemSta
 	)
 
 	return nextState(sFnApplyResources)
+}
+
+func warnAboutDeadFields(s *systemState) error {
+	if s.instance.Spec.FunctionTimeoutSec != "" {
+		s.warningBuilder.With(functionTimeoutDepreciationMessage)
+	}
+	if s.instance.Spec.FunctionRequestBodyLimitMb != "" {
+		s.warningBuilder.With(functionRequestBodyLimitDepreciationMessage)
+	}
+	return nil
 }
 
 func updateControllerConfigurationStatus(ctx context.Context, r *reconciler, instance *v1alpha1.Serverless) error {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Warn users in case they use one of non used fields (`spec.functionTimeoutSec`, `spec.functionRequestBodyLimitMb`)

**Related issue(s)**
#899 
