### PR TITLE
Show warning in UI when internal docker registry is configured

### DIFF
--- a/config/operator/base/ui-extensions/serverless/details
+++ b/config/operator/base/ui-extensions/serverless/details
@@ -9,10 +9,6 @@ body:
   - name: Desired Specification
     widget: Panel
     children:
-      - widget: Alert
-        severity: warning
-        alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
-        visibility: "$root.spec.dockerRegistry.enableInternal = true"
       - name: Docker Registry
         visibility: $root.spec.dockerRegistry.enableInternal = true
         source: spec.dockerRegistry.enableInternal?"INTERNAL":""
@@ -57,6 +53,11 @@ body:
       - name: Target CPU utilisation for HPA
         source: spec.targetCPUUtilizationPercentage
         visibility: '$exists($value)'
+  - simple: true
+    widget: Alert
+    severity: warning
+    alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
+    visibility: "$root.spec.dockerRegistry.enableInternal = true"
   - name: Status
     widget: Panel
     children:

--- a/config/operator/base/ui-extensions/serverless/details
+++ b/config/operator/base/ui-extensions/serverless/details
@@ -6,6 +6,10 @@ header:
       positive:
         - 'Ready'
 body:
+  - widget: Alert
+    severity: warning
+    source: '"alert.internalregistry"'
+    visibility: $root.spec.dockerRegistry.enableInternal = true
   - name: Desired Specification
     widget: Panel
     children:
@@ -53,11 +57,6 @@ body:
       - name: Target CPU utilisation for HPA
         source: spec.targetCPUUtilizationPercentage
         visibility: '$exists($value)'
-  - simple: true
-    widget: Alert
-    severity: warning
-    alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
-    visibility: "$root.spec.dockerRegistry.enableInternal = true"
   - name: Status
     widget: Panel
     children:

--- a/config/operator/base/ui-extensions/serverless/details
+++ b/config/operator/base/ui-extensions/serverless/details
@@ -9,6 +9,10 @@ body:
   - name: Desired Specification
     widget: Panel
     children:
+      - widget: Alert
+        severity: warning
+        alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
+        visibility: "$root.spec.dockerRegistry.enableInternal = true"
       - name: Docker Registry
         visibility: $root.spec.dockerRegistry.enableInternal = true
         source: spec.dockerRegistry.enableInternal?"INTERNAL":""

--- a/config/operator/base/ui-extensions/serverless/form
+++ b/config/operator/base/ui-extensions/serverless/form
@@ -4,7 +4,7 @@
 - simple: true
   widget: Alert
   severity: warning
-  alert: "'Internal Docker Registry is not recommended for production grade installations'"
+  alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
   visibility: "$root.spec.dockerRegistry.enableInternal = true"
 - path: spec.dockerRegistry.secretName
   visibility: $root.spec.dockerRegistry.enableInternal != true

--- a/config/operator/base/ui-extensions/serverless/form
+++ b/config/operator/base/ui-extensions/serverless/form
@@ -4,8 +4,8 @@
 - simple: true
   widget: Alert
   severity: warning
-  alert: "'Internal Docker Registry is not a highly available registry and should be used for development purpose only'"
-  visibility: "$root.spec.dockerRegistry.enableInternal = true"
+  alert: '"alert.internalregistry"'
+  visibility: $root.spec.dockerRegistry.enableInternal = true
 - path: spec.dockerRegistry.secretName
   visibility: $root.spec.dockerRegistry.enableInternal != true
   simple: true

--- a/config/operator/base/ui-extensions/serverless/kustomization.yaml
+++ b/config/operator/base/ui-extensions/serverless/kustomization.yaml
@@ -1,11 +1,12 @@
 configMapGenerator:
-- name: serverless.operator.kyma-project.io
+- name: operator.kyma-project.io
   namespace: kyma-system
   files:
   - general
   - form
   - list
   - details
+  - translations
   options:
     disableNameSuffixHash: true
     labels:

--- a/config/operator/base/ui-extensions/serverless/kustomization.yaml
+++ b/config/operator/base/ui-extensions/serverless/kustomization.yaml
@@ -1,6 +1,6 @@
 configMapGenerator:
-- name: operator.kyma-project.io
-  namespace: kube-public
+- name: serverless.operator.kyma-project.io
+  namespace: kyma-system
   files:
   - general
   - form

--- a/config/operator/base/ui-extensions/serverless/translations
+++ b/config/operator/base/ui-extensions/serverless/translations
@@ -1,0 +1,2 @@
+en:
+  alert.internalregistry: Internal Docker Registry is not a highly available registry and should be used for development purpose only


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Emit warning if non HA docker registry is used 
