### PR TITLE
Add inline hint how to switch to mjs syntax

### DIFF
--- a/config/serverless/templates/busola-serverless-extension.yaml
+++ b/config/serverless/templates/busola-serverless-extension.yaml
@@ -587,6 +587,17 @@ data:
           source:
             inline:
               source: |-
+                /*
+                If you prefer mjs import/export syntax over cjs you need to specify
+                'type': 'module'
+                in the Function dependencies (package.json) and along with that change the import/export syntax to:
+                import foo from 'foo'
+                export function main(event, context) {
+                  //your logic using foo library
+                  return
+                }
+                */
+                
                 module.exports = {
                   main: async function (event, context) {
                     const message = `Hello World`

--- a/config/serverless/templates/busola-serverless-extension.yaml
+++ b/config/serverless/templates/busola-serverless-extension.yaml
@@ -241,10 +241,20 @@ data:
           defaultExpanded: true
           subscribe:
             sourceType: |-
-              $sourceType = 'Inline' ? $language = 'JavaScript' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "module.exports = {
+              $sourceType = 'Inline' ? $language = 'JavaScript' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "/*
+              If you prefer mjs import/export syntax over cjs you need to specify
+                'type': 'module'
+              in the Function dependencies (package.json) and along with that change the import/export syntax to:
+              import foo from 'foo'
+              export function main(event, context) {
+                //your logic using foo library
+                return
+              }
+              */
+
+              module.exports = {
                 main: async function (event, context) {
                   var queryParams = event['extensions']['request']['query'];
-    
                   //read query param, for example `?greeting=Hi`
                   var greetingMsg = queryParams['greeting']; 
                   if(!greetingMsg) {
@@ -267,7 +277,18 @@ data:
                   return message" :
               '' : ''
             language: |-
-              $language = 'JavaScript' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "module.exports = {
+              $language = 'JavaScript' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "/*
+              If you prefer mjs import/export syntax over cjs you need to specify
+                'type': 'module'
+              in the Function dependencies (package.json) and along with that change the import/export syntax to:
+              import foo from 'foo'
+              export function main(event, context) {
+                //your logic using foo library
+                return
+              }
+              */
+
+              module.exports = {
                 main: async function (event, context) {
                   var queryParams = event['extensions']['request']['query'];
     


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add inline comment into generated node function templates that mentions how to switch to mjs syntax

**Related issue(s)**
[#965 ](https://github.com/kyma-project/serverless/issues/947)