### PR TITLE
call lint and markdown gh workflows from push and pull workflows

### DIFF
--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -1,8 +1,7 @@
 name: lint
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  workflow_call:
 
 jobs:
   operator-lint:

--- a/.github/workflows/_markdown.yaml
+++ b/.github/workflows/_markdown.yaml
@@ -3,8 +3,7 @@ run-name: ${{github.event.pull_request.title}}
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ "main", "release-*" ]
+  workflow_call:
 
 jobs:
   documentation-link-check:

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -9,6 +9,9 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  lint:
+    uses: ./.github/workflows/_lint.yaml
+
   unit-tests:
     uses: ./.github/workflows/_unit-tests.yaml
   

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ "main", "release-*" ]
 
 jobs:
+  markdown:
+    uses: ./.github/workflows/_markdown.yaml
+
   builds:
     uses: ./.github/workflows/_build.yaml
   


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- call lint and markdown gh workflows from push and pull workflows

**Related issue(s)**
See also #1070 