### PR TITLE
allow paralell run for unit-test and build gh workflows

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -30,6 +30,14 @@ jobs:
       dockerfile: components/operator/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
 
+#  build-gitserver:
+#    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+#    with:
+#      name: gitserver
+#      dockerfile: Dockerfile
+#      context: tests/gitserver
+#      tags: ${{ needs.compute-tags.outputs.tags }}
+
   build-serverless-controller:
     needs: compute-tags
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/_images-verify.yaml
   
   builds:
-    needs: [unit-tests, gitleaks, images-verify]
+    needs: [images-verify]
     uses: ./.github/workflows/_build.yaml
   
   integrations:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- allow paralell run for unit-test and build gh workflows
- add commented build-gitserver gh job

**Related issue(s)**
See also #1070 