### PR TITLE
Limit Python images bump to patch version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,6 +88,10 @@ updates:
     commit-message:
       prefix: "python39"
       include: "scope"
+    ignore:
+      # ignore minor python updates, e.g. 3.9 -> 3.12
+      - dependency-name: kyma-project/prod/external/library/python"
+        update-types: ["version-update:semver-minor"]
   - package-ecosystem: "docker"
     directory: "/components/runtimes/python/python312"
     labels:
@@ -98,6 +102,10 @@ updates:
     commit-message:
       prefix: "python312"
       include: "scope"
+    ignore:
+      # ignore minor python updates, e.g. 3.9 -> 3.12
+      - dependency-name: kyma-project/prod/external/library/python"
+        update-types: ["version-update:semver-minor"]
   - package-ecosystem: "docker"
     directory: "/components/runtimes/python/nodejs18"
     labels:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Limit Python images bump to patch version to keep it from trying to update Python 3.9 to 3.12

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/pull/1117/