### PR TITLE
Tests and bump k8s from 1.29 to 1.30

### DIFF
--- a/.github/actions/create-k3d-cluster/action.yaml
+++ b/.github/actions/create-k3d-cluster/action.yaml
@@ -10,7 +10,7 @@ runs:
         cluster-name: "k3dCluster"
         args: >-
           --agents 1
-          --image rancher/k3s:v1.29.3-k3s1
+          --image rancher/k3s:v1.30.5-k3s1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
           --wait

--- a/.github/actions/create-k3d-cluster/action.yaml
+++ b/.github/actions/create-k3d-cluster/action.yaml
@@ -10,7 +10,7 @@ runs:
         cluster-name: "k3dCluster"
         args: >-
           --agents 1
-          --image rancher/k3s:v1.30.5-k3s1
+          --image rancher/k3s:v1.30.0-k3s1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
           --wait

--- a/hack/gardener.mk
+++ b/hack/gardener.mk
@@ -12,7 +12,7 @@ SHOOT=test-${GIT_COMMIT_SHA}
 ifneq (,$(GARDENER_SA_PATH))
 GARDENER_K8S_VERSION=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
 else
-GARDENER_K8S_VERSION=1.30.5
+GARDENER_K8S_VERSION=1.30.0
 endif
 
 .PHONY: provision-gardener

--- a/hack/gardener.mk
+++ b/hack/gardener.mk
@@ -12,7 +12,7 @@ SHOOT=test-${GIT_COMMIT_SHA}
 ifneq (,$(GARDENER_SA_PATH))
 GARDENER_K8S_VERSION=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
 else
-GARDENER_K8S_VERSION=1.29.3
+GARDENER_K8S_VERSION=1.30.5
 endif
 
 .PHONY: provision-gardener


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
 Upgrading k8s in tests due to planned K8s Upgrade (from v.1.29 to v.1.30) in managed kyma runtime

**Related**
https://github.com/kyma-project/serverless/pull/913