### PR TITLE
Prevent requeueing after 1s when the validation failed

### DIFF
--- a/components/serverless/internal/controllers/serverless/validation.go
+++ b/components/serverless/internal/controllers/serverless/validation.go
@@ -11,6 +11,7 @@ import (
 	v1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 )
 
@@ -45,7 +46,7 @@ func stateFnValidateFunction(_ context.Context, r *reconciler, s *systemState) (
 	if len(validationResults) != 0 {
 		msg := strings.Join(validationResults, ". ")
 		cond := createValidationFailedCondition(msg)
-		r.result.Requeue = false
+		r.result = ctrl.Result{Requeue: false}
 		return buildStatusUpdateStateFnWithCondition(cond), nil
 	}
 	return stateFnInitialize, nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Pass whole object to requeue instead of `requeue=false` to aviod triggering `requeueAfter` loop

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also 
- #1204 
- #1205
