### PR TITLE
Run integration tests with k8s v1.31

### DIFF
--- a/.github/actions/create-k3d-cluster/action.yaml
+++ b/.github/actions/create-k3d-cluster/action.yaml
@@ -8,6 +8,7 @@ runs:
       uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
       with:
         cluster-name: "k3dCluster"
+        k3d-version: "v5.7.4"
         args: >-
           --agents 1
           --image rancher/k3s:v1.31.2-k3s1

--- a/.github/actions/create-k3d-cluster/action.yaml
+++ b/.github/actions/create-k3d-cluster/action.yaml
@@ -10,7 +10,7 @@ runs:
         cluster-name: "k3dCluster"
         args: >-
           --agents 1
-          --image rancher/k3s:v1.30.0-k3s1
+          --image rancher/k3s:v1.31.2-k3s1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
           --wait

--- a/hack/gardener.mk
+++ b/hack/gardener.mk
@@ -12,7 +12,7 @@ SHOOT=test-${GIT_COMMIT_SHA}
 ifneq (,$(GARDENER_SA_PATH))
 GARDENER_K8S_VERSION=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
 else
-GARDENER_K8S_VERSION=1.30.5
+GARDENER_K8S_VERSION=1.31.2
 endif
 
 .PHONY: provision-gardener


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- k8s upgrade to v1.31 is planned for managed kyma runtimes; hence we should test compatibility with out integration tests
