### PR TITLE
Remove redundant userFunction span

### DIFF
--- a/components/runtimes/nodejs/lib/tracer.js
+++ b/components/runtimes/nodejs/lib/tracer.js
@@ -61,17 +61,22 @@ function setupTracer(){
     propagator: propagator,
   });
 
-  return opentelemetry.trace.getTracer("tracer");
+  return opentelemetry.trace.getTracer("io.kyma-project.serverless");
 };
 
 module.exports = {
     setupTracer,
-    startNewSpan
+    startNewSpan,
+    getCurrentSpan,
 }
 
 
+function getCurrentSpan(){
+  return opentelemetry.trace.getSpan(opentelemetry.context.active());
+}
+
 function startNewSpan(name, tracer){
-  const currentSpan = opentelemetry.trace.getSpan(opentelemetry.context.active());
+  const currentSpan = getCurrentSpan();
   const ctx = opentelemetry.trace.setSpan(
       opentelemetry.context.active(),
       currentSpan

--- a/components/runtimes/python/kubeless.py
+++ b/components/runtimes/python/kubeless.py
@@ -58,11 +58,10 @@ if __name__ == "__main__":
 def func_with_context(e, function_context):
     ex = e.ceHeaders["extensions"]
     with set_req_context(ex["request"]):
-        with tracer.start_as_current_span("userFunction"):
-            try:
-                return func(e, function_context)
-            except Exception as e:
-                return e
+        try:
+            return func(e, function_context)
+        except Exception as e:
+            return e
 
 
 @app.get('/favicon.ico')

--- a/examples/custom-serverless-runtime-image/kubeless.py
+++ b/examples/custom-serverless-runtime-image/kubeless.py
@@ -58,11 +58,10 @@ if __name__ == "__main__":
 def func_with_context(e, function_context):
     ex = e.ceHeaders["extensions"]
     with set_req_context(ex["request"]):
-        with tracer.start_as_current_span("userFunction"):
-            try:
-                return func(e, function_context)
-            except Exception as e:
-                return e
+        try:
+            return func(e, function_context)
+        except Exception as e:
+            return e
 
 
 @app.get('/favicon.ico')


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove built-in `userFunction` trace span that is redundant
- rename the tracer (built-in in serverless framework) to `io.kyma-project.serverless`


**Related issue(s)**
#1300 