### PR TITLE
Validate spec.runtime for git functions as well

### DIFF
--- a/components/serverless/internal/controllers/serverless/validation.go
+++ b/components/serverless/internal/controllers/serverless/validation.go
@@ -3,6 +3,8 @@ package serverless
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	serverlessv1alpha2 "github.com/kyma-project/serverless/components/serverless/pkg/apis/serverless/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
@@ -12,7 +14,6 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"strings"
 )
 
 var _ stateFn = stateFnValidateFunction
@@ -131,7 +132,11 @@ func secretNamesAreUnique(secretMounts []serverlessv1alpha2.SecretMount) bool {
 func validateInlineDeps(runtime serverlessv1alpha2.Runtime, inlineSource *serverlessv1alpha2.InlineSource) validationFn {
 	return func() []string {
 		if inlineSource == nil {
-			return []string{}
+			if err := serverlessv1alpha2.ValidateRuntime(runtime); err != nil {
+				return []string{
+					fmt.Sprint(err.Error()),
+				}
+			}
 		}
 		if err := serverlessv1alpha2.ValidateDependencies(runtime, inlineSource.Dependencies); err != nil {
 			return []string{

--- a/components/serverless/internal/controllers/serverless/validation_test.go
+++ b/components/serverless/internal/controllers/serverless/validation_test.go
@@ -58,6 +58,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -79,6 +80,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -100,6 +102,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -121,6 +124,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -142,6 +146,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -160,6 +165,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -179,6 +185,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -200,6 +207,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -221,6 +229,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -242,6 +251,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -263,6 +273,7 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -278,6 +289,7 @@ func TestValidation_Invalid(t *testing.T) {
 		"Build limits memory are smaller than minimum without requests": {
 			fn: serverlessv1alpha2.Function{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -294,6 +306,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					Env: []corev1.EnvVar{
 						{Name: "1ENV"},
 						{Name: "2ENV"},
@@ -306,6 +319,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					SecretMounts: []serverlessv1alpha2.SecretMount{
 						{
 							SecretName: "secret-name-1",
@@ -324,6 +338,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					SecretMounts: []serverlessv1alpha2.SecretMount{
 						{
 							SecretName: "secret-name-1",
@@ -361,6 +376,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					Labels: map[string]string{
 						".invalid-name": "value",
 					},
@@ -372,6 +388,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					Labels: map[string]string{
 						"name": ".invalid-value",
 					},
@@ -383,6 +400,7 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
 					Annotations: map[string]string{
 						".invalid-name": "value",
 					},
@@ -439,10 +457,10 @@ func TestValidation_Invalid(t *testing.T) {
 					Labels: map[string]string{
 						"name": "fn",
 					},
-					Runtime: "nodejs18",
+					Runtime: "makapaka",
 				},
 			},
-			expectedCondMsg: "cannot find runtime: nodejs18",
+			expectedCondMsg: "cannot find runtime: makapaka",
 		},
 	}
 

--- a/components/serverless/internal/controllers/serverless/validation_test.go
+++ b/components/serverless/internal/controllers/serverless/validation_test.go
@@ -58,7 +58,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -80,7 +79,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -102,7 +100,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -124,7 +121,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -146,7 +142,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -165,7 +160,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -185,7 +179,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -207,7 +200,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -229,7 +221,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -251,7 +242,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -273,7 +263,6 @@ func TestValidation_Invalid(t *testing.T) {
 					GenerateName: "test-fn",
 				},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -289,7 +278,6 @@ func TestValidation_Invalid(t *testing.T) {
 		"Build limits memory are smaller than minimum without requests": {
 			fn: serverlessv1alpha2.Function{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 						Build: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
@@ -306,7 +294,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					Env: []corev1.EnvVar{
 						{Name: "1ENV"},
 						{Name: "2ENV"},
@@ -319,7 +306,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					SecretMounts: []serverlessv1alpha2.SecretMount{
 						{
 							SecretName: "secret-name-1",
@@ -338,7 +324,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					SecretMounts: []serverlessv1alpha2.SecretMount{
 						{
 							SecretName: "secret-name-1",
@@ -376,7 +361,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					Labels: map[string]string{
 						".invalid-name": "value",
 					},
@@ -388,7 +372,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					Labels: map[string]string{
 						"name": ".invalid-value",
 					},
@@ -400,7 +383,6 @@ func TestValidation_Invalid(t *testing.T) {
 			fn: serverlessv1alpha2.Function{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
 				Spec: serverlessv1alpha2.FunctionSpec{
-					Runtime: serverlessv1alpha2.NodeJs22,
 					Annotations: map[string]string{
 						".invalid-name": "value",
 					},

--- a/components/serverless/internal/controllers/serverless/validation_test.go
+++ b/components/serverless/internal/controllers/serverless/validation_test.go
@@ -432,6 +432,18 @@ func TestValidation_Invalid(t *testing.T) {
 			},
 			expectedCondMsg: "source.gitRepository.URL: parse \"g0t@github.com:kyma-project/kyma.git\": invalid URI for request",
 		},
+		"Invalid runtime": {
+			fn: serverlessv1alpha2.Function{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-fn"},
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"name": "fn",
+					},
+					Runtime: "nodejs18",
+				},
+			},
+			expectedCondMsg: "cannot find runtime: nodejs18",
+		},
 	}
 
 	//WHEN

--- a/components/serverless/pkg/apis/serverless/v1alpha2/runtime_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/runtime_validation.go
@@ -16,6 +16,13 @@ func ValidateDependencies(runtime Runtime, dependencies string) error {
 	return fmt.Errorf("cannot find runtime: %s", runtime)
 }
 
+func ValidateRuntime(runtime Runtime) error {
+	if runtime != NodeJs20 && runtime != NodeJs22 && runtime != Python312 {
+		return fmt.Errorf("cannot find runtime: %s", runtime)
+	}
+	return nil
+}
+
 func validateNodeJSDependencies(dependencies string) error {
 	if deps := strings.TrimSpace(dependencies); deps != "" && (deps[0] != '{' || deps[len(deps)-1] != '}') {
 		return errors.New("deps should start with '{' and end with '}'")

--- a/components/serverless/pkg/apis/serverless/v1alpha2/runtime_validation.go
+++ b/components/serverless/pkg/apis/serverless/v1alpha2/runtime_validation.go
@@ -17,7 +17,7 @@ func ValidateDependencies(runtime Runtime, dependencies string) error {
 }
 
 func ValidateRuntime(runtime Runtime) error {
-	if runtime != NodeJs20 && runtime != NodeJs22 && runtime != Python312 {
+	if len(runtime) > 0 && runtime != NodeJs20 && runtime != NodeJs22 && runtime != Python312 {
 		return fmt.Errorf("cannot find runtime: %s", runtime)
 	}
 	return nil


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use the same validation function for validating `spec.runtime` also for git functions

**Related issue(s)**
#1325 