### PR TITLE
Adjust buildless to cloud events

### DIFF
--- a/components/buildless-serverless/Makefile
+++ b/components/buildless-serverless/Makefile
@@ -25,6 +25,9 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Setting APP_NAME for local development
+APP_NAME = "buildless-serverless"
+
 .PHONY: all
 all: build
 
@@ -138,6 +141,20 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
+build-image: ## Build buildless serverless backend image
+	docker build -t $(APP_NAME) -f Dockerfile .
+
+######## disable operator to prevent undo of local image update to k3d
+disable-operator:
+	kubectl scale deployment serverless-operator -n kyma-system --replicas=0
+
+.PHONY: install-buildless
+install-buildless: build-image disable-operator## Build buildless serverless image and install it on local k3d cluster
+	$(eval HASH_TAG=$(shell docker images $(APP_NAME):latest --quiet))
+	docker tag $(APP_NAME) $(APP_NAME):$(HASH_TAG)
+
+	k3d image import $(APP_NAME):$(HASH_TAG) -c kyma
+	kubectl set image deployment -n kyma-system buildless-serverless-controller-manager manager=$(APP_NAME):$(HASH_TAG)
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/components/buildless-serverless/internal/config/function_config.go
+++ b/components/buildless-serverless/internal/config/function_config.go
@@ -8,4 +8,5 @@ type FunctionConfig struct {
 	RequeueDuration                 time.Duration `envconfig:"default=1m"`
 	FunctionReadyRequeueDuration    time.Duration `envconfig:"default=5m"`
 	PackageRegistryConfigSecretName string        `envconfig:"default=buildless-serverless-package-registry-config"`
+	FunctionPublisherProxyAddress   string        `envconfig:"default=http://eventing-publisher-proxy.kyma-system.svc.cluster.local/publish"`
 }

--- a/components/buildless-serverless/internal/controller/resources/deployment.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment.go
@@ -132,9 +132,9 @@ func (d *Deployment) podSpec() corev1.PodSpec {
 }
 
 func (d *Deployment) replicas() *int32 {
-	replicas := &d.function.Spec.Replicas
+	replicas := d.function.Spec.Replicas
 	if replicas != nil {
-		return *replicas
+		return replicas
 	}
 	defaultValue := DefaultDeploymentReplicas
 	return &defaultValue
@@ -330,20 +330,4 @@ func (d *Deployment) deploymentSecretVolumes() (volumes []corev1.Volume, volumeM
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
 	return volumes, volumeMounts
-}
-
-// security context is set to fulfill the baseline security profile
-// based on https://raw.githubusercontent.com/kyma-project/community/main/concepts/psp-replacement/baseline-pod-spec.yaml
-func (d *Deployment) restrictiveContainerSecurityContext() *corev1.SecurityContext {
-	defaultProcMount := corev1.DefaultProcMount
-	return &corev1.SecurityContext{
-		Privileged: ptr.To[bool](false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{
-				"ALL",
-			},
-		},
-		ProcMount:              &defaultProcMount,
-		ReadOnlyRootFilesystem: ptr.To[bool](true),
-	}
 }

--- a/components/buildless-serverless/internal/controller/resources/deployment.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment.go
@@ -124,8 +124,6 @@ func (d *Deployment) podSpec() corev1.PodSpec {
 					PeriodSeconds:    5,
 					TimeoutSeconds:   4,
 				},
-				//TODO: uncomment later - now we need greater privileges for running npm command
-				// SecurityContext: d.restrictiveContainerSecurityContext(),
 			},
 		},
 	}

--- a/components/buildless-serverless/internal/controller/resources/deployment.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment.go
@@ -275,6 +275,10 @@ func (d *Deployment) envs() []corev1.EnvVar {
 			Name:  "FUNC_HANDLER_DEPENDENCIES",
 			Value: spec.Source.Inline.Dependencies,
 		},
+		{
+			Name:  "PUBLISHER_PROXY_ADDRESS",
+			Value: d.functionConfig.FunctionPublisherProxyAddress,
+		},
 	}
 	if spec.Runtime == serverlessv1alpha2.Python312 {
 		envs = append(envs, []corev1.EnvVar{
@@ -288,7 +292,7 @@ func (d *Deployment) envs() []corev1.EnvVar {
 			},
 		}...)
 	}
-	envs = append(envs, spec.Env...)
+	envs = append(envs, spec.Env...) //TODO: this order is critical, should we provide option for users to override envs?
 	return envs
 }
 

--- a/components/buildless-serverless/internal/controller/resources/deployment_test.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment_test.go
@@ -648,6 +648,7 @@ func TestDeployment_envs(t *testing.T) {
 	tests := []struct {
 		name     string
 		function *serverlessv1alpha2.Function
+		fnConfig config.FunctionConfig
 		want     []corev1.EnvVar
 	}{
 		{
@@ -671,6 +672,10 @@ func TestDeployment_envs(t *testing.T) {
 				{
 					Name:  "FUNC_HANDLER_DEPENDENCIES",
 					Value: "function-dependencies",
+				},
+				{
+					Name:  "PUBLISHER_PROXY_ADDRESS",
+					Value: "test-proxy-address",
 				},
 			},
 		},
@@ -697,6 +702,10 @@ func TestDeployment_envs(t *testing.T) {
 					Value: "function-dependencies-py",
 				},
 				{
+					Name:  "PUBLISHER_PROXY_ADDRESS",
+					Value: "test-proxy-address",
+				},
+				{
 					Name:  "MOD_NAME",
 					Value: "handler",
 				},
@@ -711,6 +720,9 @@ func TestDeployment_envs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &Deployment{
 				function: tt.function,
+				functionConfig: &config.FunctionConfig{
+					FunctionPublisherProxyAddress: "test-proxy-address",
+				},
 			}
 
 			r := d.envs()

--- a/components/buildless-serverless/internal/controller/state/handle_deployment.go
+++ b/components/buildless-serverless/internal/controller/state/handle_deployment.go
@@ -106,7 +106,8 @@ func deploymentChanged(a *appsv1.Deployment, b *appsv1.Deployment) bool {
 		!reflect.DeepEqual(aSpec.Command, bSpec.Command) ||
 		!reflect.DeepEqual(aSpec.Resources, bSpec.Resources) ||
 		!reflect.DeepEqual(aSpec.Env, bSpec.Env) ||
-		!reflect.DeepEqual(aSpec.VolumeMounts, bSpec.VolumeMounts)
+		!reflect.DeepEqual(aSpec.VolumeMounts, bSpec.VolumeMounts) ||
+		!reflect.DeepEqual(aSpec.Ports, bSpec.Ports)
 }
 
 func updateDeployment(ctx context.Context, m *fsm.StateMachine, clusterDeployment *appsv1.Deployment) (*ctrl.Result, error) {

--- a/config/buildless-serverless/templates/deployment.yaml
+++ b/config/buildless-serverless/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: "{{ .Values.global.containerRegistry.path }}/{{ $p312.directory }}/{{$p312.name}}:{{$p312.version}}"
             - name: APP_FUNCTION_PACKAGE_REGISTRY_CONFIG_SECRET_NAME
               value: "{{- tpl ( .Values.containers.manager.configuration.data.packageRegistryConfigSecretName) . }}"
+            - name: APP_FUNCTION_PUBLISHER_PROXY_ADDRESS
+              value: "{{.Values.containers.manager.configuration.data.functionPublisherProxyAddress }}"
       securityContext:
         runAsNonRoot: true
         runAsGroup: 1000

--- a/config/buildless-serverless/values.yaml
+++ b/config/buildless-serverless/values.yaml
@@ -19,3 +19,4 @@ containers:
     configuration:
       data:
         packageRegistryConfigSecretName: 'serverless-package-registry-config'
+        functionPublisherProxyAddress: "http://eventing-publisher-proxy.kyma-system.svc.cluster.local/publish"

--- a/tests/serverless/internal/resources/runtimes/python.go
+++ b/tests/serverless/internal/resources/runtimes/python.go
@@ -151,12 +151,7 @@ def main(event, context):
 				Dependencies: dpd,
 			},
 		},
-		Env: []v1.EnvVar{
-			{
-				Name:  "PUBLISHER_PROXY_ADDRESS",
-				Value: "localhost:8080",
-			},
-		},
+		Env: []v1.EnvVar{},
 		ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
 			Function: &serverlessv1alpha2.ResourceRequirements{
 				Profile: "L",
@@ -227,10 +222,6 @@ def main(event, context):
 			},
 		},
 		Env: []v1.EnvVar{
-			{
-				Name:  "PUBLISHER_PROXY_ADDRESS",
-				Value: "localhost:8080",
-			},
 			{
 				Name:  "CE_SOURCE",
 				Value: string(runtime),


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add probes to deployment
- Add publisher proxy address
- Add local target to test `buildless` without waiting for building image on PR
- Adjust `deployment_test`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1211 