### PR TITLE
Fix Language dropdown population

### DIFF
--- a/config/serverless/templates/busola-serverless-extension.yaml
+++ b/config/serverless/templates/busola-serverless-extension.yaml
@@ -173,8 +173,8 @@ data:
       enum: [JavaScript, Python]
       trigger: [language]
       dynamicValue: |
-        spec.runtime in ['nodejs20', 'nodejs22'] ? 'JavaScript' :
-        spec.runtime in ['python312'] ? 'Python' :
+        $contains(status.runtime, 'nodejs') ? 'JavaScript' :
+        $contains(status.runtime, 'python') ? 'Python' :
         ''
     - simple: true
       path: spec.runtime


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make sure that `Language` field is populated based on status.runtime (inclusively wrt. deprecated/removed runtimes)