### PR TITLE
Do not fix static namespace for resources in buildless chart

### DIFF
--- a/config/buildless-serverless/templates/busola-serverless-extension.yaml
+++ b/config/buildless-serverless/templates/busola-serverless-extension.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: functions
-  namespace: kube-public
+  namespace: {{ .Release.Namespace }}
   labels:
     busola.io/extension: resource
     busola.io/extension-version: '0.5'

--- a/config/buildless-serverless/templates/cluster-role-binding.yaml
+++ b/config/buildless-serverless/templates/cluster-role-binding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: buildless-serverless-controller-manager
-    namespace: kyma-system
+    namespace: {{ .Release.Namespace }}

--- a/config/buildless-serverless/templates/deployment.yaml
+++ b/config/buildless-serverless/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: buildless-serverless
     control-plane: controller-manager
   name: buildless-serverless-controller-manager
-  namespace: kyma-system
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/config/buildless-serverless/templates/leader-election-role-binding.yaml
+++ b/config/buildless-serverless/templates/leader-election-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: buildless-serverless
   name: buildless-serverless-leader-election-rolebinding
-  namespace: kyma-system
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,4 +13,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: buildless-serverless-controller-manager
-    namespace: kyma-system
+    namespace: {{ .Release.Namespace }}

--- a/config/buildless-serverless/templates/leader-election-role.yaml
+++ b/config/buildless-serverless/templates/leader-election-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: buildless-serverless
   name: buildless-serverless-leader-election-role
-  namespace: kyma-system
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/config/buildless-serverless/templates/service-account.yaml
+++ b/config/buildless-serverless/templates/service-account.yaml
@@ -5,4 +5,4 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: buildless-serverless
   name: buildless-serverless-controller-manager
-  namespace: kyma-system
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- operator should install module where serverless CR is installed - not fixed to kyma-system

**Related issue(s)**
#1211 