### PR TITLE
Add missing selector

### DIFF
--- a/config/operator/base/deployment/deployment.yaml
+++ b/config/operator/base/deployment/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       control-plane: operator
+      app.kubernetes.io/component: serverless-operator.kyma-project.io
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add the `app.kubernetes.io/component: serverless-operator.kyma-project.io` selector because it was removed by mistake from the operator manifest

**Issue/s:**
- https://github.com/kyma-project/serverless/issues/1409