### PR TITLE
add status for errors during git auth preparation

### DIFF
--- a/components/buildless-serverless/internal/controller/state/handle_git_sources.go
+++ b/components/buildless-serverless/internal/controller/state/handle_git_sources.go
@@ -24,6 +24,11 @@ func sFnHandleGitSources(ctx context.Context, m *fsm.StateMachine) (fsm.StateFn,
 	if m.State.Function.HasGitAuth() {
 		gitAuth, err := git.NewGitAuth(ctx, m.Client, &m.State.Function)
 		if err != nil {
+			m.State.Function.UpdateCondition(
+				serverlessv1alpha2.ConditionConfigurationReady,
+				metav1.ConditionFalse,
+				serverlessv1alpha2.ConditionReasonGitSourceCheckFailed,
+				fmt.Sprintf("Getting git authorization data failed: %s", err.Error()))
 			return nil, nil, err
 		}
 		m.State.GitAuth = gitAuth


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add status (condition) for errors during git auth preparation

**Related issue(s)**
See also:
- #1485 