### PR TITLE
Add x-kubernetes-validation tests in Buildless

### DIFF
--- a/components/buildless-serverless/Makefile
+++ b/components/buildless-serverless/Makefile
@@ -5,7 +5,7 @@ PROJECT_ROOT = ../..
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.30.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/components/buildless-serverless/Makefile
+++ b/components/buildless-serverless/Makefile
@@ -5,7 +5,7 @@ PROJECT_ROOT = ../..
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
+++ b/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
@@ -32,7 +32,88 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 	testCases := map[string]struct {
 		fn *serverlessv1alpha2.Function
 	}{
-		"valid inline source with Python runtime": {
+		"Profile set only for function": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{Function: &serverlessv1alpha2.ResourceRequirements{
+						Profile: "XS",
+					}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Function profile S": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{
+							Profile: "S",
+						}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Function profile M": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{
+							Profile: "M",
+						}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Function profile L": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{
+							Profile: "L",
+						}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Function profile XL": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{
+							Profile: "XL",
+						}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Resource set only for function": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{Resources: &corev1.ResourceRequirements{}}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"Valid inline source with Python runtime": {
 			fn: &serverlessv1alpha2.Function{
 				ObjectMeta: fixMetadata,
 				Spec: serverlessv1alpha2.FunctionSpec{
@@ -346,6 +427,40 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 		fieldPath      string
 		expectedCause  metav1.CauseType
 	}{
+		"Resource and Profiles used together in function": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{Function: &serverlessv1alpha2.ResourceRequirements{
+						Profile:   "L",
+						Resources: &corev1.ResourceRequirements{},
+					}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			expectedErrMsg: "Use profile or resources",
+			fieldPath:      "spec.resourceConfiguration.function",
+		},
+		"Invalid profile in function": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					ResourceConfiguration: &serverlessv1alpha2.ResourceConfiguration{
+						Function: &serverlessv1alpha2.ResourceRequirements{
+							Profile: "SS",
+						}},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			expectedErrMsg: "Invalid profile, please use one of: [",
+			fieldPath:      "spec.resourceConfiguration.function",
+		},
 		"labels use exact restricted domain": {
 			fn: &serverlessv1alpha2.Function{
 				ObjectMeta: fixMetadata,

--- a/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
+++ b/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
@@ -1,0 +1,723 @@
+package v1alpha2_test
+
+import (
+	"context"
+	serverlessv1alpha2 "github.com/kyma-project/serverless/api/v1alpha2"
+	"github.com/kyma-project/serverless/internal/testenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"strings"
+	"testing"
+)
+
+func Test_XKubernetesValidations_Valid(t *testing.T) {
+	fixMetadata := metav1.ObjectMeta{
+		GenerateName: "test",
+		Namespace:    "test",
+	}
+	ctx := context.TODO()
+	k8sClient, testEnv := testenv.Start(t)
+	defer testenv.Stop(t, testEnv)
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	err := k8sClient.Create(ctx, &testNs)
+	require.NoError(t, err)
+
+	// GIVEN
+	testCases := map[string]struct {
+		fn *serverlessv1alpha2.Function
+	}{
+		"valid inline source with Python runtime": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{
+							Source:       "print('Hello, World!')",
+							Dependencies: "requests==2.25.1",
+						},
+					},
+					Replicas: pointer.Int32(1),
+				},
+			},
+		},
+		"labels has value with special characters similar to restricted one ": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"serverless$kyma-project#io/abc": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"labels has value restricted domain without path ": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"serverless.kyma-project.io": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"labels not use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"my.label.com": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"similar label not use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"serverless.kyma-project.label.com": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"annotations has value with special characters similar to restricted one ": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"serverless$kyma-project#io/abc": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"annotations has value restricted domain without path ": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"serverless.kyma-project.io": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"annotations not use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"my.label.com": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"annotations label not use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"serverless.kyma-project.label.com": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+		},
+		"allowed runtime: nodejs20": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs20,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+				},
+			},
+		},
+		"allowed runtime: nodejs22": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+				},
+			},
+		},
+		"allowed runtime: python312": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+				},
+			},
+		},
+		"allowed envs": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Env: []corev1.EnvVar{{Name: "TEST_ENV"}, {Name: "MY_ENV"}},
+				},
+			},
+		},
+		"gitRepository used as source": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "base-dir",
+								Reference: "ref",
+							},
+						},
+					},
+				},
+			},
+		},
+		"Git source has auth with key Type": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "ref",
+							},
+							Auth: &serverlessv1alpha2.RepositoryAuth{
+								Type:       "key",
+								SecretName: "secret",
+							},
+						},
+					},
+				},
+			},
+		},
+		"Git source has auth with basic Type": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "ref",
+							},
+							Auth: &serverlessv1alpha2.RepositoryAuth{
+								Type:       "basic",
+								SecretName: "secret",
+							},
+						},
+					},
+				},
+			},
+		},
+		"valid Git source with Node.js runtime": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs20,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							URL: "https://github.com/example/repo.git",
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "src",
+								Reference: "main",
+							},
+						},
+					},
+					Replicas: pointer.Int32(2),
+				},
+			},
+		},
+		"valid Git source with authentication": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.NodeJs22,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							URL: "git@github.com:example/repo.git",
+							Auth: &serverlessv1alpha2.RepositoryAuth{
+								Type:       serverlessv1alpha2.RepositoryAuthSSHKey,
+								SecretName: "git-ssh-secret",
+							},
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "app",
+								Reference: "develop",
+							},
+						},
+					},
+					Replicas: pointer.Int32(3),
+				},
+			},
+		},
+		"label value length is 63": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "abc"}},
+					Labels: map[string]string{
+						strings.Repeat("a", 63): "test",
+					},
+				},
+			},
+		},
+		"secretMount": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "abc"}},
+					SecretMounts: []serverlessv1alpha2.SecretMount{{MountPath: "/path", SecretName: "secret-name"}},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			err := k8sClient.Create(ctx, tc.fn)
+
+			// THEN
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_XKubernetesValidations_Invalid(t *testing.T) {
+	fixMetadata := metav1.ObjectMeta{
+		GenerateName: "test",
+		Namespace:    "test",
+	}
+	ctx := context.TODO()
+	k8sClient, testEnv := testenv.Start(t)
+	defer testenv.Stop(t, testEnv)
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	err := k8sClient.Create(ctx, &testNs)
+	require.NoError(t, err)
+
+	//GIVEN
+	testCases := map[string]struct {
+		fn             *serverlessv1alpha2.Function
+		expectedErrMsg string
+		fieldPath      string
+		expectedCause  metav1.CauseType
+	}{
+		"labels use exact restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"serverless.kyma-project.io/": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.labels",
+			expectedErrMsg: "Labels has key starting with ",
+		},
+		"labels use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"serverless.kyma-project.io/abc": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.labels",
+			expectedErrMsg: "Labels has key starting with ",
+		},
+		"labels has many values with incorrect one": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Labels: map[string]string{
+						"app":                            "mySuperApp",
+						"serverless.kyma-project.io/abc": "labelValue",
+						"service":                        "mySvc",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.labels",
+			expectedErrMsg: "Labels has key starting with ",
+		},
+		"annotations use exact restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"serverless.kyma-project.io/": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.annotations",
+			expectedErrMsg: "Annotations has key starting with ",
+		},
+		"annotations has many values with incorrect one": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"app":                            "mySuperApp",
+						"serverless.kyma-project.io/abc": "labelValue",
+						"service":                        "mySvc",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.annotations",
+			expectedErrMsg: "Annotations has key starting with ",
+		},
+		"annotations use restricted domain": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Annotations: map[string]string{
+						"serverless.kyma-project.io/abc": "labelValue",
+					},
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+			fieldPath:      "spec.annotations",
+			expectedErrMsg: "Annotations has key starting with ",
+		},
+		"reserved env: FUNC_RUNTIME": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "FUNC_RUNTIME"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"reserved env: FUNC_HANDLER": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "FUNC_HANDLER"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"reserved env: FUNC_PORT": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "FUNC_PORT"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"reserved env: MOD_NAME": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "MOD_NAME"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"reserved env: NODE_PATH": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "NODE_PATH"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"reserved env: PYTHONPATH": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Python312,
+					Env: []corev1.EnvVar{
+						{Name: "TEST2"},
+						{Name: "PYTHONPATH"},
+						{Name: "TEST"},
+					},
+				},
+			},
+			expectedErrMsg: "Following envs are reserved",
+			fieldPath:      "spec.env",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"GitRepository and Inline source used together": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: nil,
+						Inline:        nil,
+					},
+				},
+			},
+			expectedErrMsg: "Use GitRepository or Inline source",
+			fieldPath:      "spec.source",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Neither GitRepository nor Inline source was used": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source:  serverlessv1alpha2.Source{},
+				},
+			},
+			expectedErrMsg: "Use GitRepository or Inline source",
+			fieldPath:      "spec.source",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Secret Mount name is empty": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source:  serverlessv1alpha2.Source{Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					SecretMounts: []serverlessv1alpha2.SecretMount{
+						{SecretName: "", MountPath: "/path"},
+					},
+				},
+			},
+			expectedErrMsg: "should be at least 1 chars long",
+			fieldPath:      "spec.secretMounts[0].secretName",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Secret Mount path is empty": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source:  serverlessv1alpha2.Source{Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					SecretMounts: []serverlessv1alpha2.SecretMount{
+						{SecretName: "my-secret", MountPath: ""},
+					},
+				},
+			},
+			expectedErrMsg: "should be at least 1 chars long",
+			fieldPath:      "spec.secretMounts[0].mountPath",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Label value is longer than 63 charts": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source:  serverlessv1alpha2.Source{Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Labels: map[string]string{
+						strings.Repeat("a", 64): "test",
+					},
+				},
+			},
+			expectedErrMsg: "Label value cannot be longer than 63",
+			fieldPath:      "spec.labels",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Inline source is empty": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{},
+					},
+				},
+			},
+			expectedErrMsg: "should be at least 1 chars long",
+			fieldPath:      "spec.source.inline.source",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Git source has empty BaseDir": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "   ",
+								Reference: "ref",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "BaseDir is required and cannot be empty",
+			fieldPath:      "spec.source.gitRepository",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Git source has empty Reference": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "   ",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "Reference is required and cannot be empty",
+			fieldPath:      "spec.source.gitRepository",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+		"Git source has empty SecretName": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "ref",
+							},
+							Auth: &serverlessv1alpha2.RepositoryAuth{
+								Type:       "key",
+								SecretName: "  ",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "SecretName is required and cannot be empty",
+			fieldPath:      "spec.source.gitRepository.auth.secretName",
+			expectedCause:  metav1.CauseTypeFieldValueInvalid,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			//WHEN
+			err := k8sClient.Create(ctx, tc.fn)
+			//THEN
+			require.Error(t, err)
+			errStatus, ok := err.(*k8serrors.StatusError)
+			require.True(t, ok)
+			causes := errStatus.Status().Details.Causes
+			require.Len(t, causes, 1)
+			cause := causes[0]
+			assert.Equal(t, tc.expectedCause, cause.Type)
+			assert.Equal(t, tc.fieldPath, cause.Field)
+			assert.NotEmpty(t, tc.expectedErrMsg, "cause message: %s", cause.Message)
+			assert.Equal(t, cause.Message, tc.expectedErrMsg)
+		})
+	}
+}

--- a/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
+++ b/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
@@ -2,6 +2,9 @@ package v1alpha2_test
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	serverlessv1alpha2 "github.com/kyma-project/serverless/api/v1alpha2"
 	"github.com/kyma-project/serverless/internal/testenv"
 	"github.com/stretchr/testify/assert"
@@ -9,9 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"strings"
-	"testing"
 )
 
 func Test_XKubernetesValidations_Valid(t *testing.T) {
@@ -124,7 +124,6 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 							Dependencies: "requests==2.25.1",
 						},
 					},
-					Replicas: pointer.Int32(1),
 				},
 			},
 		},
@@ -343,7 +342,6 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 							},
 						},
 					},
-					Replicas: pointer.Int32(2),
 				},
 			},
 		},
@@ -365,7 +363,6 @@ func Test_XKubernetesValidations_Valid(t *testing.T) {
 							},
 						},
 					},
-					Replicas: pointer.Int32(3),
 				},
 			},
 		},

--- a/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
+++ b/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
@@ -360,7 +360,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.labels",
-			expectedErrMsg: "Labels has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Labels has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"labels use restricted domain": {
 			fn: &serverlessv1alpha2.Function{
@@ -376,7 +376,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.labels",
-			expectedErrMsg: "Labels has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Labels has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"labels has many values with incorrect one": {
 			fn: &serverlessv1alpha2.Function{
@@ -394,7 +394,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.labels",
-			expectedErrMsg: "Labels has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Labels has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"annotations use exact restricted domain": {
 			fn: &serverlessv1alpha2.Function{
@@ -410,7 +410,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.annotations",
-			expectedErrMsg: "Annotations has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Annotations has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"annotations has many values with incorrect one": {
 			fn: &serverlessv1alpha2.Function{
@@ -428,7 +428,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.annotations",
-			expectedErrMsg: "Annotations has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Annotations has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"annotations use restricted domain": {
 			fn: &serverlessv1alpha2.Function{
@@ -444,7 +444,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 			fieldPath:      "spec.annotations",
-			expectedErrMsg: "Annotations has key starting with ",
+			expectedErrMsg: "Invalid value: \"object\": Annotations has key starting with serverless.kyma-project.io/ which is not allowed",
 		},
 		"reserved env: FUNC_RUNTIME": {
 			fn: &serverlessv1alpha2.Function{
@@ -460,7 +460,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -478,7 +478,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -496,7 +496,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -514,7 +514,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -532,7 +532,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -550,7 +550,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Following envs are reserved",
+			expectedErrMsg: "Invalid value: \"array\": Following envs are reserved and cannot be used: ['FUNC_RUNTIME','FUNC_HANDLER','FUNC_PORT','FUNC_HANDLER_SOURCE','FUNC_HANDLER_DEPENDENCIES','MOD_NAME','NODE_PATH','PYTHONPATH']",
 			fieldPath:      "spec.env",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -565,7 +565,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Use GitRepository or Inline source",
+			expectedErrMsg: "Invalid value: \"object\": Use GitRepository or Inline source",
 			fieldPath:      "spec.source",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -577,7 +577,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					Source:  serverlessv1alpha2.Source{},
 				},
 			},
-			expectedErrMsg: "Use GitRepository or Inline source",
+			expectedErrMsg: "Invalid value: \"object\": Use GitRepository or Inline source",
 			fieldPath:      "spec.source",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -592,7 +592,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "should be at least 1 chars long",
+			expectedErrMsg: "Invalid value: \"\": spec.secretMounts[0].secretName in body should be at least 1 chars long",
 			fieldPath:      "spec.secretMounts[0].secretName",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -607,7 +607,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "should be at least 1 chars long",
+			expectedErrMsg: "Invalid value: \"\": spec.secretMounts[0].mountPath in body should be at least 1 chars long",
 			fieldPath:      "spec.secretMounts[0].mountPath",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -622,7 +622,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Label value cannot be longer than 63",
+			expectedErrMsg: "Invalid value: \"object\": Label value cannot be longer than 63",
 			fieldPath:      "spec.labels",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -636,7 +636,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "should be at least 1 chars long",
+			expectedErrMsg: "Invalid value: \"\": spec.source.inline.source in body should be at least 1 chars long",
 			fieldPath:      "spec.source.inline.source",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -655,7 +655,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "BaseDir is required and cannot be empty",
+			expectedErrMsg: "Invalid value: \"object\": BaseDir is required and cannot be empty",
 			fieldPath:      "spec.source.gitRepository",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -674,7 +674,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "Reference is required and cannot be empty",
+			expectedErrMsg: "Invalid value: \"object\": Reference is required and cannot be empty",
 			fieldPath:      "spec.source.gitRepository",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -697,7 +697,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "SecretName is required and cannot be empty",
+			expectedErrMsg: "Invalid value: \"string\": SecretName is required and cannot be empty",
 			fieldPath:      "spec.source.gitRepository.auth.secretName",
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
 		},
@@ -717,7 +717,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			assert.Equal(t, tc.expectedCause, cause.Type)
 			assert.Equal(t, tc.fieldPath, cause.Field)
 			assert.NotEmpty(t, tc.expectedErrMsg, "cause message: %s", cause.Message)
-			assert.Equal(t, cause.Message, tc.expectedErrMsg)
+			assert.Equal(t, tc.expectedErrMsg, cause.Message)
 		})
 	}
 }

--- a/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
+++ b/components/buildless-serverless/api/v1alpha2/function_x_validation_test.go
@@ -441,7 +441,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 				},
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
-			expectedErrMsg: "Use profile or resources",
+			expectedErrMsg: "Invalid value: \"object\": Use profile or resources",
 			fieldPath:      "spec.resourceConfiguration.function",
 		},
 		"Invalid profile in function": {
@@ -458,7 +458,7 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 				},
 			},
 			expectedCause:  metav1.CauseTypeFieldValueInvalid,
-			expectedErrMsg: "Invalid profile, please use one of: [",
+			expectedErrMsg: "Invalid value: \"object\": Invalid profile, please use one of: ['XS','S','M','L','XL']",
 			fieldPath:      "spec.resourceConfiguration.function",
 		},
 		"labels use exact restricted domain": {
@@ -833,6 +833,91 @@ func Test_XKubernetesValidations_Invalid(t *testing.T) {
 			assert.Equal(t, tc.fieldPath, cause.Field)
 			assert.NotEmpty(t, tc.expectedErrMsg, "cause message: %s", cause.Message)
 			assert.Equal(t, tc.expectedErrMsg, cause.Message)
+		})
+	}
+}
+
+// in some cases k8s 1.30+ returns two reasons
+func Test_XKubernetesValidations_InvalidMultipleCauses(t *testing.T) {
+	fixMetadata := metav1.ObjectMeta{
+		GenerateName: "test",
+		Namespace:    "test",
+	}
+	ctx := context.TODO()
+	k8sClient, testEnv := testenv.Start(t)
+	defer testenv.Stop(t, testEnv)
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+	err := k8sClient.Create(ctx, &testNs)
+	require.NoError(t, err)
+
+	//GIVEN
+	testCases := map[string]struct {
+		fn             *serverlessv1alpha2.Function
+		expectedErrMsg string
+		fieldPath      string
+		expectedCause  metav1.CauseType
+	}{
+		"disallowed runtime: custom": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Source: serverlessv1alpha2.Source{
+						Inline: &serverlessv1alpha2.InlineSource{Source: "a"}},
+					Runtime: serverlessv1alpha2.Runtime("custom"),
+				},
+			},
+			expectedCause:  metav1.CauseTypeFieldValueNotSupported,
+			fieldPath:      "spec.runtime",
+			expectedErrMsg: "Unsupported value: \"custom\": supported values: \"nodejs20\", \"nodejs22\", \"python312\"",
+		},
+		"Git source auth has incorrect Type": {
+			fn: &serverlessv1alpha2.Function{
+				ObjectMeta: fixMetadata,
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: serverlessv1alpha2.Python312,
+					Source: serverlessv1alpha2.Source{
+						GitRepository: &serverlessv1alpha2.GitRepositorySource{
+							Repository: serverlessv1alpha2.Repository{
+								BaseDir:   "dir",
+								Reference: "ref",
+							},
+							Auth: &serverlessv1alpha2.RepositoryAuth{
+								Type:       "custom",
+								SecretName: "secret",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsg: "Unsupported value: \"custom\": supported values: \"basic\", \"key\"",
+			fieldPath:      "spec.source.gitRepository.auth.type",
+			expectedCause:  metav1.CauseTypeFieldValueNotSupported,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			//WHEN
+			err := k8sClient.Create(ctx, tc.fn)
+
+			//THEN
+			require.Error(t, err)
+			errStatus, ok := err.(*k8serrors.StatusError)
+			require.True(t, ok)
+			causes := errStatus.Status().Details.Causes
+			require.Len(t, causes, 2)
+			causeFound := false
+			for _, cause := range causes {
+				if cause.Type == tc.expectedCause && cause.Field == tc.fieldPath {
+					causeFound = true
+					assert.Equal(t, tc.expectedCause, cause.Type)
+					assert.Equal(t, tc.fieldPath, cause.Field)
+					assert.NotEmpty(t, tc.expectedErrMsg, "cause message: %s", cause.Message)
+					assert.Equal(t, tc.expectedErrMsg, cause.Message)
+				}
+			}
+			assert.True(t, causeFound)
 		})
 	}
 }

--- a/components/buildless-serverless/internal/testenv/testenv.go
+++ b/components/buildless-serverless/internal/testenv/testenv.go
@@ -1,0 +1,56 @@
+package testenv
+
+import (
+	serverlessv1alpha2 "github.com/kyma-project/serverless/api/v1alpha2"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/scheme"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"strings"
+	"testing"
+)
+
+func Start(t *testing.T) (cl client.Client, env *envtest.Environment) {
+	wdPath, err := os.Getwd()
+	require.NoError(t, err)
+	crdPath := buildPathFromProjectRoot(wdPath, "components", "buildless-serverless", "config", "crd", "bases")
+	envtestBinsPath := buildPathFromProjectRoot(wdPath, "components", "buildless-serverless", "bin", "k8s", "kubebuilder_assets")
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdPath},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: envtestBinsPath,
+	}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	require.NoError(t, scheme.AddToScheme(scheme.Scheme))
+	require.NoError(t, serverlessv1alpha2.AddToScheme(scheme.Scheme))
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+	require.NotNil(t, k8sClient)
+
+	return k8sClient, testEnv
+}
+
+func Stop(t *testing.T, testEnv *envtest.Environment) {
+	require.NoError(t, testEnv.Stop())
+}
+
+func buildPathFromProjectRoot(wd string, dirs ...string) string {
+	wdPath := strings.Split(wd, "/")
+
+	path := []string{"/"}
+	for _, dir := range wdPath {
+		if dir == "components" {
+			break
+		}
+		path = append(path, dir)
+	}
+	path = append(path, dirs...)
+	return filepath.Join(path...)
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add `function_x_validation_test` for `buildless` based on old `serverless`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
