### PR TITLE
Stop using configPath in cli extension

### DIFF
--- a/config/serverless/files/kyma-commands.yaml
+++ b/config/serverless/files/kyma-commands.yaml
@@ -1,7 +1,3 @@
-with:
-  resource:
-    apiVersion: serverless.kyma-project.io/v1alpha2
-    kind: Function
 metadata:
   name: function
   description: A set of commands for managing Functions
@@ -16,20 +12,24 @@ subCommands:
   args:
     type: string
     optional: true
-    configPath: ".resource.metadata.name"
   flags:
   - type: string
     name: "namespace"
     shorthand: "n"
     description: "Function's namespace"
-    configPath: ".resource.metadata.namespace"
     default: "default"
   - type: bool
     name: "all-namespaces"
     shorthand: "A"
-    configPath: ".fromAllNamespaces"
     default: false
   with:
+    fromAllNamespaces: ${{.flags.allnamespaces.value}}
+    resource:
+      apiVersion: serverless.kyma-project.io/v1alpha2
+      kind: Function
+      metadata:
+        name: ${{.args.value}}
+        namespace: ${{.flags.namespace.value}}
     outputParameters:
     - resourcePath: '.status.conditions[] | select(.type=="ConfigurationReady") | .status'
       name: "configured"
@@ -64,14 +64,19 @@ subCommands:
   uses: resource_delete
   args:
     type: string
-    configPath: ".resource.metadata.name"
   flags:
   - type: string
     name: "namespace"
     shorthand: "n"
     description: "Function's namespace"
-    configPath: ".resource.metadata.namespace"
     default: "default"
+  with:
+    resource:
+      apiVersion: serverless.kyma-project.io/v1alpha2
+      kind: Function
+      metadata:
+        name: ${{ .args.value }}
+        namespace: ${{ .flags.namespace.value }}
 
 - metadata:
     name: "create <resource_name> [flags]"
@@ -80,34 +85,29 @@ subCommands:
   uses: resource_create
   args:
     type: string
-    configPath: ".resource.metadata.name"
   flags:
   - type: string
     name: "runtime-image-override"
     description: "custom runtime image to be used as Function's runtime base"
-    configPath: ".resource.spec.runtimeImageOverride"
+    default: "\"\""
   - type: string
     name: "namespace"
     shorthand: "n"
     description: "Function's namespace"
-    configPath: ".resource.metadata.namespace"
     default: "default"
   - type: string
     name: "runtime"
     description: "function runtime"
     shorthand: "r"
-    configPath: ".resource.spec.runtime"
     default: "nodejs22"
   - type: int
     name: "replicas"
     description: "function replicas"
-    configPath: ".resource.spec.replicas"
     default: "1"
   - type: path
     name: "source"
     description: "function source file path"
     shorthand: "s"
-    configPath: ".resource.spec.source.inline.source"
     default: |
       module.exports = {
         main: function(event, context) {
@@ -118,7 +118,27 @@ subCommands:
     name: "dependencies"
     description: "function dependencies file path"
     shorthand: "d"
-    configPath: ".resource.spec.source.inline.dependencies"
+    default: |
+      {
+        "dependencies": {}
+      }
+  with:
+    resource:
+      apiVersion: serverless.kyma-project.io/v1alpha2
+      kind: Function
+      metadata:
+        name: ${{ .args.value }}
+        namespace: ${{ .flags.namespace.value }}
+      spec:
+        runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+        runtime: ${{ .flags.runtime.value }}
+        replicas: ${{ .flags.replicas.value }}
+        source:
+          inline:
+            source: |
+              ${{ .flags.source.value | newLineIndent 20 }}
+            dependencies: |
+              ${{ .flags.dependencies.value | newLineIndent 20 }}
 
 - metadata:
     name: "init [flags]"
@@ -127,16 +147,16 @@ subCommands:
   uses: function_init
   flags:
   - name: runtime
-    configPath: ".useRuntime"
     type: string
     description: "Runtime for which the files are generated [ nodejs22, nodejs20, python312 ]"
     default: "nodejs22"
   - name: dir
-    configPath: ".outputDir"
     type: string
     description: "Path to the directory where files must be created"
     default: "."
   with:
+    useRuntime: ${{ .flags.runtime.value }}
+    outputDir: ${{ .flags.dir.value }}
     runtimes:
       python312:
         depsFilename: requirements.txt


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- migrate from the `configPath` inside the `flags` and `args` into go templates in the `with` config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2428