### PR TITLE
disable leader election for development use

### DIFF
--- a/components/buildless-serverless/hack/function-config.yaml
+++ b/components/buildless-serverless/hack/function-config.yaml
@@ -1,5 +1,5 @@
 metricsAddress: ":8080"
-leaderElectionEnabled: true
+leaderElectionEnabled: false
 healthzAddress: ":8090"
 images:
   repoFetcher: "europe-docker.pkg.dev/kyma-project/prod/function-buildless-init:main"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- disable leader election for development use (to avoid: https://book.kubebuilder.io/faq#after-make-run-i-see-errors-like-unable-to-find-leader-election-namespace-not-running-in-cluster)

