### PR TITLE
Adjust limits of the XS profile to accomodate npm/pip installation in the runtime

### DIFF
--- a/components/buildless-serverless/hack/function-config.yaml
+++ b/components/buildless-serverless/hack/function-config.yaml
@@ -19,8 +19,8 @@ resourcesConfiguration:
         XS:
           requestCpu: "50m"
           requestMemory: "64Mi"
-          limitCpu: "100m"
-          limitMemory: "128Mi"
+          limitCpu: "150m"
+          limitMemory: "192Mi"
         S:
           requestCpu: "100m"
           requestMemory: "128Mi"

--- a/config/buildless-serverless/values.yaml
+++ b/config/buildless-serverless/values.yaml
@@ -53,8 +53,8 @@ containers:
                 XS:
                   requestCpu: "50m"
                   requestMemory: "64Mi"
-                  limitCpu: "100m"
-                  limitMemory: "128Mi"
+                  limitCpu: "150m"
+                  limitMemory: "192Mi"
                 S:
                   requestCpu: "100m"
                   requestMemory: "128Mi"

--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -204,8 +204,8 @@ containers:
                 XS:
                   requestCpu: "50m"
                   requestMemory: "64Mi"
-                  limitCpu: "100m"
-                  limitMemory: "128Mi"
+                  limitCpu: "150m"
+                  limitMemory: "192Mi"
                 S:
                   requestCpu: "100m"
                   requestMemory: "128Mi"

--- a/docs/user/technical-reference/07-80-available-presets.md
+++ b/docs/user/technical-reference/07-80-available-presets.md
@@ -15,7 +15,7 @@ For example, to modify the default values for **buildResources**, remove all its
 
 | Preset | Request CPU | Request memory | Limit CPU | Limit memory |
 | - | - | - | - | - |
-| `XS` | `50m` | `64Mi` | `100m` | `128Mi` |
+| `XS` | `50m` | `64Mi` | `150m` | `192Mi` |
 | `S` | `100m` | `128Mi` | `200m` | `256Mi` |
 | `M` | `200m` | `256Mi` | `400m` | `512Mi` |
 | `L` | `400m` | `512Mi` | `800m` | `1024Mi` |


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump cpu limit for XS by 50% (as pip install is at the limit with just 100m)
- bump memory limit for XS by 50% (as npm install OOM crashed the pod if a function introduces a couple of dependecies )

**Related issue(s)**
#1640 