### PR TITLE
Build old serverless on amd64 only

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -77,6 +77,7 @@ jobs:
       dockerfile: components/serverless/deploy/manager/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
       build-engine: buildx
+      platforms: linux/amd64 # this image does not support arm64
 
   build-buildless-serverless-controller:
     needs: compute-tags
@@ -104,6 +105,7 @@ jobs:
       dockerfile: components/serverless/deploy/jobinit/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
       build-engine: buildx
+      platforms: linux/amd64 # this image does not support arm64
 
   build-buildless-serverless-jobinit:
     needs: compute-tags

--- a/components/serverless/deploy/jobinit/Dockerfile
+++ b/components/serverless/deploy/jobinit/Dockerfile
@@ -1,11 +1,9 @@
-FROM --platform=$BUILDPLATFORM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.24.4-alpine3.22 AS builder
-
-ARG TARGETOS TARGETARCH
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.24.4-alpine3.22 AS builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/serverless \
     CGO_ENABLED=1 \
-    GOOS=$TARGETOS \
-    GOARCH=$TARGETARCH \
+    GOOS=linux \
+    GOARCH=amd64 \
     LIBGIT2_VERSION=1.5.2-r0
 
 RUN apk add --no-cache gcc libc-dev

--- a/components/serverless/deploy/manager/Dockerfile
+++ b/components/serverless/deploy/manager/Dockerfile
@@ -1,11 +1,9 @@
-FROM --platform=$BUILDPLATFORM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.24.4-alpine3.22 AS builder
-
-ARG TARGETOS TARGETARCH
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.24.4-alpine3.22 AS builder
 
 ENV BASE_APP_DIR=/workspace/go/src/github.com/kyma-project/serverless \
     CGO_ENABLED=1 \
-    GOOS=$TARGETOS \
-    GOARCH=$TARGETARCH \
+    GOOS=linux \
+    GOARCH=amd64 \
     LIBGIT2_VERSION=1.5.2-r0
 
 RUN apk add --no-cache gcc libc-dev


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- old serverless does not support arm64 builds because of the gcc and libgit2 dependencies

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1746