### PR TITLE
Ensure istioNativeSidecars for all buildless git functions 

### DIFF
--- a/components/buildless-serverless/internal/controller/resources/deployment.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment.go
@@ -113,7 +113,7 @@ func (d *Deployment) currentAnnotationsWithoutPreviousFunctionAnnotations() map[
 func (d *Deployment) annotationsRequiredByIstio() map[string]string {
 	result := make(map[string]string)
 
-	if d.function.HasGitSources() && d.function.HasLabel(istioInjectSidecarLabelKey, "true") {
+	if d.function.HasGitSources() {
 		result[istioNativeSidecarLabelKey] = "true"
 	}
 

--- a/components/buildless-serverless/internal/controller/resources/deployment_test.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment_test.go
@@ -143,7 +143,7 @@ func TestDeployment_construct(t *testing.T) {
 			"thompson":              "exciting",
 		}, r.Spec.Template.ObjectMeta.Annotations)
 	})
-	t.Run("enable native sidecar when istio is enabled and function has git repo", func(t *testing.T) {
+	t.Run("enable native sidecar when function has git repo", func(t *testing.T) {
 		d := minimalDeployment()
 
 		d.function.Spec.Source = serverlessv1alpha2.Source{
@@ -152,10 +152,6 @@ func TestDeployment_construct(t *testing.T) {
 				Repository: serverlessv1alpha2.Repository{
 					BaseDir:   "recursing-mcnulty",
 					Reference: "epic-mendel"}}}
-
-		d.function.Spec.Labels = map[string]string{
-			"sidecar.istio.io/inject": "true",
-		}
 
 		r := d.construct()
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- ensuring `sidecar.istio.io/nativeSidecar: "true"` regardless if `sidecar.istio.io/inject: "true"` is present on the function, as function runtime pod may be included in istio mesh via configuration on namespace level.

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/1642