### PR TITLE
Add authorization to target downloading Kustomize installation script

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -43,9 +43,6 @@ $(KUSTOMIZE): $(LOCALBIN)
 		test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) --header "Authorization: Bearer ${GITHUB_TOKEN}" | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }; \
 	fi
 
-
-
-
 ########## Controller-Gen ###########
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen


### PR DESCRIPTION
**Description**
Added an if to the make target checking whether GITHUB_TOKEN exists and using it to authorizate if it does.

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/1771
