### PR TITLE
Flush python print() to stdout

### DIFF
--- a/components/buildless-serverless/internal/controller/resources/deployment.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment.go
@@ -508,8 +508,8 @@ func (d *Deployment) envs() []corev1.EnvVar {
 				Value: "main",
 			},
 			{
-				Name:  "PYTHONBUFFERED",
-				Value: "1",
+				Name:  "PYTHONUNBUFFERED",
+				Value: "TRUE",
 			},
 		}...)
 	}

--- a/components/buildless-serverless/internal/controller/resources/deployment_test.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment_test.go
@@ -1174,8 +1174,8 @@ func TestDeployment_envs(t *testing.T) {
 					Value: "main",
 				},
 				{
-					Name:  "PYTHONBUFFERED",
-					Value: "1",
+					Name:  "PYTHONUNBUFFERED",
+					Value: "TRUE",
 				},
 			},
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Set `PYTHONBUFFERED` env to flush print() to stdout immediatelly

**Related issue(s)**
#1801 