### PR TITLE
Added separate create commands for each runtime

### DIFF
--- a/config/buildless-serverless/files/kyma-commands.yaml
+++ b/config/buildless-serverless/files/kyma-commands.yaml
@@ -86,9 +86,9 @@ subCommands:
         namespace: ${{ .flags.namespace.value }}
 
 - metadata:
-    name: "create <resource_name> [flags]"
+    name: "create"
     description: "Create Function"
-    descriptionLong: "Use this command to create Function on a cluster."
+    descriptionLong: "Use this command to create a Function with the default NodeJS 22 runtime on a cluster."
   uses: resource_create
   args:
     type: string
@@ -102,11 +102,6 @@ subCommands:
     shorthand: "n"
     description: "Function's namespace"
     default: "default"
-  - type: string
-    name: "runtime"
-    description: "function runtime"
-    shorthand: "r"
-    default: "nodejs22"
   - type: int
     name: "replicas"
     description: "function replicas"
@@ -153,7 +148,7 @@ subCommands:
         namespace: ${{ .flags.namespace.value }}
       spec:
         runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
-        runtime: ${{ .flags.runtime.value }}
+        runtime: nodejs22
         replicas: ${{ .flags.replicas.value }}
         env: ${{ .flags.env.value | toEnvs }}
         secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
@@ -163,6 +158,220 @@ subCommands:
               ${{ .flags.source.value | newLineIndent 20 }}
             dependencies: |
               ${{ .flags.dependencies.value | newLineIndent 20 }}
+  subCommands:
+    - metadata:
+        name: "python312 <resource_name> [flags]"
+        description: "Create Python 3.12 Function"
+        descriptionLong: "Use this command to create a Function with Python 3.12 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          def main(event, context):
+            return "Hello World!"
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: ""
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: python312
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
+    - metadata:
+        name: "nodejs20 <resource_name> [flags]"
+        description: "Create Node.js 20 Function"
+        descriptionLong: "Use this command to create a Function with Node.js 20 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          module.exports = {
+            main: function(event, context) {
+              return 'Hello World!'
+            }
+          }
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: |
+          {
+            "dependencies": {}
+          }
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: nodejs20
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
+    - metadata:
+        name: "nodejs22 <resource_name> [flags]"
+        description: "Create Node.js 22 Function"
+        descriptionLong: "Use this command to create a Function with Node.js 22 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          module.exports = {
+            main: function(event, context) {
+              return 'Hello World!'
+            }
+          }
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: |
+          {
+            "dependencies": {}
+          }
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: nodejs22
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
 
 - metadata:
     name: "init [flags]"

--- a/config/serverless/files/kyma-commands.yaml
+++ b/config/serverless/files/kyma-commands.yaml
@@ -88,9 +88,9 @@ subCommands:
         namespace: ${{ .flags.namespace.value }}
 
 - metadata:
-    name: "create <resource_name> [flags]"
+    name: "create"
     description: "Create Function"
-    descriptionLong: "Use this command to create Function on a cluster."
+    descriptionLong: "Use this command to create a Function with the default NodeJS 22 runtime on a cluster."
   uses: resource_create
   args:
     type: string
@@ -104,11 +104,6 @@ subCommands:
     shorthand: "n"
     description: "Function's namespace"
     default: "default"
-  - type: string
-    name: "runtime"
-    description: "function runtime"
-    shorthand: "r"
-    default: "nodejs22"
   - type: int
     name: "replicas"
     description: "function replicas"
@@ -155,7 +150,7 @@ subCommands:
         namespace: ${{ .flags.namespace.value }}
       spec:
         runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
-        runtime: ${{ .flags.runtime.value }}
+        runtime: nodejs22
         replicas: ${{ .flags.replicas.value }}
         env: ${{ .flags.env.value | toEnvs }}
         secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
@@ -165,6 +160,220 @@ subCommands:
               ${{ .flags.source.value | newLineIndent 20 }}
             dependencies: |
               ${{ .flags.dependencies.value | newLineIndent 20 }}
+  subCommands:
+    - metadata:
+        name: "python312 <resource_name> [flags]"
+        description: "Create Python 3.12 Function"
+        descriptionLong: "Use this command to create a Function with Python 3.12 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          def main(event, context):
+            return "Hello World!"
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: ""
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: python312
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
+    - metadata:
+        name: "nodejs20 <resource_name> [flags]"
+        description: "Create Node.js 20 Function"
+        descriptionLong: "Use this command to create a Function with Node.js 20 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          module.exports = {
+            main: function(event, context) {
+              return 'Hello World!'
+            }
+          }
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: |
+          {
+            "dependencies": {}
+          }
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: nodejs20
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
+    - metadata:
+        name: "nodejs22 <resource_name> [flags]"
+        description: "Create Node.js 22 Function"
+        descriptionLong: "Use this command to create a Function with Node.js 22 runtime on a cluster."
+      uses: resource_create
+      args:
+        type: string
+      flags:
+      - type: string
+        name: "runtime-image-override"
+        description: "custom runtime image to be used as Function's runtime base"
+        default: "\"\""
+      - type: string
+        name: "namespace"
+        shorthand: "n"
+        description: "Function's namespace"
+        default: "default"
+      - type: int
+        name: "replicas"
+        description: "function replicas"
+        default: "1"
+      - type: path
+        name: "source"
+        description: "function source file path"
+        shorthand: "s"
+        default: |
+          module.exports = {
+            main: function(event, context) {
+              return 'Hello World!'
+            }
+          }
+      - type: path
+        name: "dependencies"
+        description: "function dependencies file path"
+        shorthand: "d"
+        default: |
+          {
+            "dependencies": {}
+          }
+      - type: map
+        name: "env"
+        description: "function environment variables in format key=value"
+      - type: map
+        name: secret-mount
+        description: "function secret mounts in format secret-name=mount-path"
+      - type: bool
+        name: "dry-run"
+        description: "Simulates resource creation if set to 'true'"
+      - type: string
+        name: output
+        shorthand: o
+        description: "Output format. It can be json or yaml."
+      with:
+        output: ${{ .flags.output.value }}
+        dryRun: ${{ .flags.dryrun.value }}
+        resource:
+          apiVersion: serverless.kyma-project.io/v1alpha2
+          kind: Function
+          metadata:
+            name: ${{ .args.value }}
+            namespace: ${{ .flags.namespace.value }}
+          spec:
+            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
+            runtime: nodejs22
+            replicas: ${{ .flags.replicas.value }}
+            env: ${{ .flags.env.value | toEnvs }}
+            secretMounts: ${{ .flags.secretmount.value | toArray "{'secretName':'{{.key}}','mountPath':'{{.value}}'}" }}
+            source:
+              inline:
+                source: |
+                  ${{ .flags.source.value | newLineIndent 20 }}
+                dependencies: |
+                  ${{ .flags.dependencies.value | newLineIndent 20 }}
 
 - metadata:
     name: "init [flags]"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Defined a specialized subcommand for each `function create` command that specified the runtime.
- Keeping the default `create` command with the default NodeJS 22 runtime.

- Functions creation:
<img width="1055" height="555" alt="Zrzut ekranu 2025-09-5 o 15 30 55" src="https://github.com/user-attachments/assets/bcc4e791-a579-45cb-87e1-f8c97e9573cd" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves kyma-project/cli#123`, `Fixes kyma-project/cli#43`, or `See also kyma-project/cli#33`. -->
[#2555](https://github.com/kyma-project/serverless/issues/1891)