### PR TITLE
Include current rma label in the allowed metric scrapers

### DIFF
--- a/config/buildless-serverless/templates/network-policies.yaml
+++ b/config/buildless-serverless/templates/network-policies.yaml
@@ -47,6 +47,9 @@ spec:
   - from:
     - podSelector:
         matchLabels:
+          app.kubernetes.io/instance: rma
+    - podSelector:
+        matchLabels:
           networking.kyma-project.io/metrics-scraping: allowed
     ports:
     - protocol: TCP

--- a/config/serverless/templates/network-policies.yaml
+++ b/config/serverless/templates/network-policies.yaml
@@ -37,6 +37,9 @@ spec:
   - from:
     - podSelector:
         matchLabels:
+          app.kubernetes.io/instance: rma
+    - podSelector:
+        matchLabels:
           networking.kyma-project.io/metrics-scraping: allowed
     ports:
     - protocol: TCP


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Include pods by `app.kubernetes.io/instance: rma` in allowed metric scrapers

**Related issue(s)**
#1530 