### PR TITLE
Improve eject endpoint to return fully functional application

### DIFF
--- a/components/buildless-serverless/Dockerfile
+++ b/components/buildless-serverless/Dockerfile
@@ -28,6 +28,7 @@ RUN apk add --no-cache ca-certificates
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM scratch
 
+COPY ./components/runtimes /runtimes/
 COPY --from=builder /app /app
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 USER 1000:1000

--- a/components/buildless-serverless/Dockerfile.dockerignore
+++ b/components/buildless-serverless/Dockerfile.dockerignore
@@ -2,5 +2,6 @@
 **
 # Allow
 !components/buildless-serverless
+!components/runtimes
 !go.sum
 !go.mod

--- a/components/buildless-serverless/internal/controller/resources/deployment_test.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment_test.go
@@ -165,13 +165,9 @@ func TestDeployment_construct(t *testing.T) {
 		require.Equal(t, "function", r.Spec.Template.Spec.Containers[0].Name)
 	})
 	t.Run("use container image based on function and function configuration", func(t *testing.T) {
-		d := &Deployment{
-			Deployment: nil,
-			functionConfig: &config.FunctionConfig{
+		d := NewDeployment(minimalFunction(), &config.FunctionConfig{
 				Images: config.ImagesConfig{Python312: "special-test-image"},
-			},
-			function: minimalFunction(),
-		}
+			}, nil, "", nil)
 
 		r := d.construct()
 
@@ -234,6 +230,7 @@ python /kubeless.py;`,
 	t.Run("use container env based on function", func(t *testing.T) {
 		d := minimalDeployment()
 		d.function.Spec.Source.Inline.Source = "special-function-source"
+		d.podEnvs = envs(d.function, d.functionConfig)
 
 		r := d.construct()
 
@@ -386,15 +383,11 @@ func TestDeployment_workingSourcesDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := &Deployment{
-				function: &serverlessv1alpha2.Function{
-					Spec: serverlessv1alpha2.FunctionSpec{
-						Runtime: tt.runtime,
-					},
+			r := workingSourcesDir(&serverlessv1alpha2.Function{
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime: tt.runtime,
 				},
-			}
-
-			r := d.workingSourcesDir()
+			})
 
 			assert.Equal(t, tt.want, r)
 		})
@@ -461,17 +454,12 @@ func TestDeployment_runtimeImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := &Deployment{
-				functionConfig: c,
-				function: &serverlessv1alpha2.Function{
-					Spec: serverlessv1alpha2.FunctionSpec{
-						Runtime:              tt.fields.runtime,
-						RuntimeImageOverride: tt.fields.runtimeImageOverride,
-					},
+			r := runtimeImage(&serverlessv1alpha2.Function{
+				Spec: serverlessv1alpha2.FunctionSpec{
+					Runtime:              tt.fields.runtime,
+					RuntimeImageOverride: tt.fields.runtimeImageOverride,
 				},
-			}
-
-			r := d.runtimeImage()
+			}, c)
 
 			assert.Equal(t, tt.want, r)
 		})
@@ -1223,15 +1211,10 @@ func TestDeployment_envs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := &Deployment{
-				function: tt.function,
-				functionConfig: &config.FunctionConfig{
-					FunctionPublisherProxyAddress:  "test-proxy-address",
-					FunctionTraceCollectorEndpoint: "test-trace-collector-endpoint",
-				},
-			}
-
-			r := d.envs()
+			r := envs(tt.function, &config.FunctionConfig{
+				FunctionPublisherProxyAddress:  "test-proxy-address",
+				FunctionTraceCollectorEndpoint: "test-trace-collector-endpoint",
+			})
 
 			assert.ElementsMatch(t, tt.want, r)
 		})
@@ -1424,11 +1407,7 @@ npm start;`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := &Deployment{
-				function: tt.function,
-			}
-
-			r := d.runtimeCommand()
+			r := runtimeCommand(tt.function)
 
 			assert.Equal(t, tt.want, r)
 		})

--- a/components/buildless-serverless/internal/controller/resources/deployment_test.go
+++ b/components/buildless-serverless/internal/controller/resources/deployment_test.go
@@ -166,8 +166,8 @@ func TestDeployment_construct(t *testing.T) {
 	})
 	t.Run("use container image based on function and function configuration", func(t *testing.T) {
 		d := NewDeployment(minimalFunction(), &config.FunctionConfig{
-				Images: config.ImagesConfig{Python312: "special-test-image"},
-			}, nil, "", nil)
+			Images: config.ImagesConfig{Python312: "special-test-image"},
+		}, nil, "", nil)
 
 		r := d.construct()
 
@@ -228,9 +228,9 @@ python /kubeless.py;`,
 		require.Equal(t, *rc.Function.Resources, r.Spec.Template.Spec.Containers[0].Resources)
 	})
 	t.Run("use container env based on function", func(t *testing.T) {
-		d := minimalDeployment()
-		d.function.Spec.Source.Inline.Source = "special-function-source"
-		d.podEnvs = envs(d.function, d.functionConfig)
+		f := minimalFunction()
+		f.Spec.Source.Inline.Source = "special-function-source"
+		d := minimalDeploymentForFunction(f)
 
 		r := d.construct()
 
@@ -1211,12 +1211,12 @@ func TestDeployment_envs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := envs(tt.function, &config.FunctionConfig{
+			d := NewDeployment(tt.function, &config.FunctionConfig{
 				FunctionPublisherProxyAddress:  "test-proxy-address",
 				FunctionTraceCollectorEndpoint: "test-trace-collector-endpoint",
-			})
+			}, nil, "", nil)
 
-			assert.ElementsMatch(t, tt.want, r)
+			assert.ElementsMatch(t, tt.want, d.podEnvs)
 		})
 	}
 }
@@ -1440,6 +1440,10 @@ func minimalFunctionConfig() *config.FunctionConfig {
 	}
 }
 
+func minimalDeploymentForFunction(f *serverlessv1alpha2.Function) *Deployment {
+	return NewDeployment(f, minimalFunctionConfig(), nil, "", nil)
+}
+
 func minimalDeployment() *Deployment {
-	return NewDeployment(minimalFunction(), minimalFunctionConfig(), nil, "", nil)
+	return minimalDeploymentForFunction(minimalFunction())
 }

--- a/components/buildless-serverless/internal/endpoint/function.go
+++ b/components/buildless-serverless/internal/endpoint/function.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	serverlessv1alpha2 "github.com/kyma-project/serverless/components/buildless-serverless/api/v1alpha2"
-	"github.com/kyma-project/serverless/components/buildless-serverless/internal/controller/git"
 	"github.com/kyma-project/serverless/components/buildless-serverless/internal/controller/resources"
+	"github.com/kyma-project/serverless/components/buildless-serverless/internal/endpoint/packagejson"
 	"github.com/pkg/errors"
 	"go.yaml.in/yaml/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,10 +45,72 @@ func (s *Server) handleFunctionRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.writeFilesListResponse(w, []FileResponse{
+	runtimeFiles, err := s.getRuntimeFiles(&function)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to get runtime files for function '%s/%s'", ns, name))
+		return
+	}
+
+	s.writeFilesListResponse(w, append(runtimeFiles, []FileResponse{
 		{Name: "service.yaml", Data: base64.StdEncoding.EncodeToString(svc)},
 		{Name: "deployment.yaml", Data: base64.StdEncoding.EncodeToString(deployment)},
-	})
+	}...))
+}
+
+func (s *Server) getRuntimeFiles(function *serverlessv1alpha2.Function) ([]FileResponse, error) {
+	if !function.HasNodejsRuntime() {
+		// TODO: support non-nodejs runtimes
+		return nil, errors.New("ejecting functions with non-nodejs runtimes is not supported")
+	}
+
+	runtimeDir := fmt.Sprintf("../runtimes/%s", function.Spec.Runtime)
+
+	packagejsonFile, err := os.ReadFile(runtimeDir + "/package.json")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read package.json")
+	}
+
+	packagejsonFile, err = packagejson.Merge([]byte(function.Spec.Source.Inline.Dependencies), packagejsonFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to merge package.json")
+	}
+
+	serverFile, err := os.ReadFile(runtimeDir + "/server.mjs")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read server.mjs")
+	}
+
+	makefileFile, err := os.ReadFile(runtimeDir + "/cli/Makefile")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read Makefile")
+	}
+
+	dockerfileFile, err := os.ReadFile(runtimeDir + "/cli/Dockerfile")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read Dockerfile")
+	}
+
+	libFilesInfo, err := os.ReadDir(runtimeDir + "/lib")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read lib directory")
+	}
+
+	libFiles := make([]FileResponse, 0, len(libFilesInfo))
+	for _, f := range libFilesInfo {
+		data, err := os.ReadFile(runtimeDir + "/lib/" + f.Name())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read lib file '%s'", f.Name())
+		}
+		libFiles = append(libFiles, FileResponse{Name: fmt.Sprintf("/lib/%s", f.Name()), Data: base64.StdEncoding.EncodeToString(data)})
+	}
+
+	return append(libFiles, []FileResponse{
+		{Name: "package.json", Data: base64.StdEncoding.EncodeToString(packagejsonFile)},
+		{Name: "server.mjs", Data: base64.StdEncoding.EncodeToString(serverFile)},
+		{Name: "Dockerfile", Data: base64.StdEncoding.EncodeToString(dockerfileFile)},
+		{Name: "handler.js", Data: base64.StdEncoding.EncodeToString([]byte(function.Spec.Source.Inline.Source))},
+		{Name: "Makefile", Data: base64.StdEncoding.EncodeToString(makefileFile)},
+	}...), nil
 }
 
 func (s *Server) buildServiceFileData(function *serverlessv1alpha2.Function) ([]byte, error) {
@@ -70,35 +133,25 @@ func (s *Server) buildServiceFileData(function *serverlessv1alpha2.Function) ([]
 }
 
 func (s *Server) buildDeploymentFileData(function *serverlessv1alpha2.Function) ([]byte, error) {
-	var commit string
-	var gitAuth *git.GitAuth
-	if function.Spec.Source.GitRepository != nil {
-		var err error
-		if function.HasGitAuth() {
-			gitAuth, err = git.NewGitAuth(s.ctx, s.k8s, function)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to create git auth")
-			}
-		}
-
-		gitRepo := function.Spec.Source.GitRepository
-		commit, err = git.GetLatestCommit(gitRepo.URL, gitRepo.Reference, gitAuth)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get latest commit")
-		}
+	if function.HasGitSources() {
+		// TODO: support git source
+		return nil, errors.New("ejecting functions with git source is not supported")
 	}
 
 	deployName := fmt.Sprintf("%s-ejected", function.Name)
 	deploy := resources.NewDeployment(
 		function,
 		&s.functionConfig, nil,
-		commit,
-		gitAuth,
-		resources.DeployName(deployName),
+		"",
+		nil,
+		resources.DeploySetName(deployName),
 		resources.DeployTrimClusterInfoLabels(),
 		resources.DeployAppendSelectorLabels(map[string]string{
 			"app.kubernetes.io/instance": deployName,
 		}),
+		resources.DeploySetCmd([]string{}), // clear the command to use the default one from the image
+		resources.DeploySetImage("image:tag"),
+		resources.DeployUseGeneralEnvs(),
 	).Deployment
 
 	data, err := convertK8SObjectToYaml(deploy)

--- a/components/buildless-serverless/internal/endpoint/packagejson/merge.go
+++ b/components/buildless-serverless/internal/endpoint/packagejson/merge.go
@@ -1,0 +1,67 @@
+package packagejson
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+func Merge(from, target []byte) ([]byte, error) {
+	fromObj := map[string]any{}
+	err := json.Unmarshal(from, &fromObj)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal source package.json")
+	}
+
+	targetObj := map[string]any{}
+	err = json.Unmarshal(target, &targetObj)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal target package.json")
+	}
+
+	merged := merge(fromObj, targetObj)
+	return json.MarshalIndent(merged, "", "  ")
+}
+
+func merge(from, target map[string]any) map[string]any {
+	for k, v := range from {
+		if _, exists := target[k]; !exists {
+			target[k] = v
+			continue
+		}
+
+		// both are maps, merge them recursively
+		fromMap, okFrom := v.(map[string]any)
+		targetMap, okTarget := target[k].(map[string]any)
+		if okFrom && okTarget {
+			target[k] = merge(fromMap, targetMap)
+			continue
+		}
+
+		// both are arrays, merge them uniquely
+		fromArr, okFrom := v.([]any)
+		targetArr, okTarget := target[k].([]any)
+		if okFrom && okTarget {
+			target[k] = mergeArrays(fromArr, targetArr)
+			continue
+		}
+
+		// otherwise, override the value
+		target[k] = v
+	}
+	return target
+}
+
+func mergeArrays(from, target []any) []any {
+	existing := map[any]bool{}
+	for _, v := range target {
+		existing[v] = true
+	}
+
+	for _, v := range from {
+		if _, exists := existing[v]; !exists {
+			target = append(target, v)
+		}
+	}
+	return target
+}

--- a/components/runtimes/nodejs20/cli/Dockerfile
+++ b/components/runtimes/nodejs20/cli/Dockerfile
@@ -1,0 +1,34 @@
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.22.1
+
+# https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.20&repo=main&arch=&maintainer=
+ENV NODE_VERSION=20.15.1-r0
+# use Ada version compatible with the Node version
+ENV ADA_VERSION=2.7.8-r0
+
+RUN apk add --no-cache openssl3
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.20/main ada-libs=2.7.8-r0 nodejs=${NODE_VERSION} npm
+
+ARG NODE_ENV
+ENV NODE_ENV=$NODE_ENV
+ENV npm_config_cache=/tmp/
+
+RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app/lib
+WORKDIR /usr/src/app
+
+COPY --chown=root:root ./package.json /usr/src/app/
+RUN chmod 644 /usr/src/app/package.json
+
+RUN npm install && npm cache clean --force
+COPY --chown=root:root ./lib /usr/src/app/lib
+RUN chmod -R 755 /usr/src/app/lib
+
+COPY --chown=root:root ./server.mjs /usr/src/app/server.mjs
+RUN chmod 644 /usr/src/app/server.mjs
+
+COPY --chown=root:root ./handler.js /usr/src/app/handler.js
+RUN chmod 644 /usr/src/app/handler.js
+
+CMD ["npm", "start"]
+
+EXPOSE 8888

--- a/components/runtimes/nodejs20/cli/Makefile
+++ b/components/runtimes/nodejs20/cli/Makefile
@@ -1,0 +1,14 @@
+START_TIME := $(shell date +%s)
+IMG ?= app:$(START_TIME)
+
+.PHONY: k3d-deploy
+k3d-deploy:
+	docker build -t $(IMG) .
+	k3d image import $(IMG)
+	yq '.spec.template.spec.containers[] |= select(.name == "function") |= .image="$(IMG)"' deployment.yaml | kubectl apply -f -
+	kubectl apply -f service.yaml
+
+.PHONY: run
+run:
+	npm install
+	npm start

--- a/components/runtimes/nodejs22/cli/Dockerfile
+++ b/components/runtimes/nodejs22/cli/Dockerfile
@@ -1,0 +1,31 @@
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.22.1
+
+# https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.21&repo=main&arch=&maintainer=
+ENV NODE_VERSION=22.16.0-r2
+
+RUN apk add --no-cache openssl3 nodejs=${NODE_VERSION} npm
+
+ARG NODE_ENV
+ENV NODE_ENV=$NODE_ENV
+ENV npm_config_cache=/tmp/
+
+RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app/lib
+WORKDIR /usr/src/app
+
+COPY --chown=root:root ./package.json /usr/src/app/
+RUN chmod 644 /usr/src/app/package.json
+
+RUN npm install && npm cache clean --force
+COPY --chown=root:root ./lib /usr/src/app/lib
+RUN chmod -R 755 /usr/src/app/lib
+
+COPY --chown=root:root ./server.mjs /usr/src/app/server.mjs
+RUN chmod 644 /usr/src/app/server.mjs
+
+COPY --chown=root:root ./handler.js /usr/src/app/handler.js
+RUN chmod 644 /usr/src/app/handler.js
+
+CMD ["npm", "start"]
+
+EXPOSE 8888

--- a/components/runtimes/nodejs22/cli/Makefile
+++ b/components/runtimes/nodejs22/cli/Makefile
@@ -1,0 +1,14 @@
+START_TIME := $(shell date +%s)
+IMG ?= app:$(START_TIME)
+
+.PHONY: k3d-deploy
+k3d-deploy:
+	docker build -t $(IMG) .
+	k3d image import $(IMG)
+	yq '.spec.template.spec.containers[] |= select(.name == "function") |= .image="$(IMG)"' deployment.yaml | kubectl apply -f -
+	kubectl apply -f service.yaml
+
+.PHONY: run
+run:
+	npm install
+	npm start


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix deployment selector (build deploy with same pod labels and pod selector)
- build buildless-controller image with runtime files
- merge function and runtime package.jsons into one
- return runtime files in response

Command result:
<img width="1122" height="507" alt="Screenshot 2025-09-11 at 17 05 48" src="https://github.com/user-attachments/assets/ddc96447-c026-489d-8359-a591ead20727" />

Generated workspace can be run locally using make:
<img width="2966" height="659" alt="Screenshot 2025-09-11 at 17 07 42" src="https://github.com/user-attachments/assets/88d76928-e4e2-4008-9e60-a7fcdd9bbefc" />


Or deployed on the k3d cluster:
<img width="2993" height="1514" alt="Screenshot 2025-09-11 at 17 09 02" src="https://github.com/user-attachments/assets/ec93665f-b261-4a97-ba13-2c2a795a98c7" />

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1838#issue-3340739984