### PR TITLE
function init CLI extensions adjustments

### DIFF
--- a/config/buildless-serverless/files/kyma-commands.yaml
+++ b/config/buildless-serverless/files/kyma-commands.yaml
@@ -358,28 +358,15 @@ subCommands:
     descriptionLong: Use this command to initialize source and dependencies files for a Function.
   uses: function_init
   flags:
-  - name: runtime
-    type: string
-    description: "Runtime for which the files are generated [ nodejs22, nodejs20, python312 ]"
-    default: "nodejs22"
   - name: dir
     type: string
     description: "Path to the directory where files must be created"
     default: "."
   with:
-    useRuntime: ${{ .flags.runtime.value }}
+    useRuntime: nodejs
     outputDir: ${{ .flags.dir.value }}
     runtimes:
-      python312:
-        depsFilename: requirements.txt
-        depsData: ""
-        handlerFilename: handler.py
-        handlerData: |
-          def main(event, context):
-            message = "Hello World from the Kyma Function "+context['function-name']+" running on "+context['runtime']+ "!";
-            print(message)
-            return message
-      nodejs22:
+      nodejs: 
         depsFilename: package.json
         depsData: |
           {
@@ -407,31 +394,86 @@ subCommands:
               return message;
             }
           }
-      nodejs20:
-        depsFilename: package.json
-        depsData: |
-          {
-            "dependencies": {}
-          }
-        handlerFilename: handler.js
-        handlerData: |
-          module.exports = {
-            main: async function (event, context) {
-              /*
-              If you prefer mjs import/export syntax over cjs you need to specify
-              'type': 'module'
-              in the Function dependencies (package.json) and along with that change the import/export syntax to:
-              import foo from 'foo'
-              export function main(event, context) {
-                //your logic using foo library
-                return
-              }
-              */
+    nextStepsInstructions: |
+      Next steps:
+      * update output files in your favorite IDE
+      * create Function, for example:
+        kyma function create nodejs my-function --source handler.js --dependencies package.json
 
-              const message = `Hello World`
-                + ` from the Kyma Function ${context["function-name"]}`
-                + ` running on ${context.runtime}!`;
-              console.log(message);
-              return message;
+  subCommands:
+  - metadata:
+      name: "nodejs [flags]"
+      description: Init source and dependencies files locally
+      descriptionLong: Use this command to initialize source and dependencies files for a Function.
+    uses: function_init
+    flags:
+    - name: dir
+      type: string
+      description: "Path to the directory where files must be created"
+      default: "."
+    with:
+      useRuntime: nodejs
+      outputDir: ${{ .flags.dir.value }}
+      nextStepsInstructions: |
+        Next steps:
+        * update output files in your favorite IDE
+        * create Function, for example:
+          kyma function create nodejs my-function --source handler.js --dependencies package.json
+      runtimes:
+        nodejs:
+          depsFilename: package.json
+          depsData: |
+            {
+              "dependencies": {}
             }
-          }
+          handlerFilename: handler.js
+          handlerData: |
+            module.exports = {
+              main: async function (event, context) {
+                /*
+                If you prefer mjs import/export syntax over cjs you need to specify
+                'type': 'module'
+                in the Function dependencies (package.json) and along with that change the import/export syntax to:
+                import foo from 'foo'
+                export function main(event, context) {
+                  //your logic using foo library
+                  return
+                }
+                */
+
+                const message = `Hello World`
+                  + ` from the Kyma Function ${context["function-name"]}`
+                  + ` running on ${context.runtime}!`;
+                console.log(message);
+                return message;
+              }
+            }
+
+  - metadata:
+      name: "python [flags]"
+      description: Init source and dependencies files locally
+      descriptionLong: Use this command to initialize source and dependencies files for a Function.
+    uses: function_init
+    flags:
+    - name: dir
+      type: string
+      description: "Path to the directory where files must be created"
+      default: "."
+    with:
+      useRuntime: python
+      outputDir: ${{ .flags.dir.value }}
+      runtimes:
+        python:
+          depsFilename: requirements.txt
+          depsData: ""
+          handlerFilename: handler.py
+          handlerData: |
+            def main(event, context):
+              message = "Hello World from the Kyma Function "+context['function-name']+" running on "+context['runtime']+ "!";
+              print(message)
+              return message
+      nextStepsInstructions: |
+        Next steps:
+        * update output files in your favorite IDE
+        * create Function, for example:
+          kyma function create python --source handler.py --dependencies requirements.txt


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Changed the `kyma function init` command to work in alignment with `function create`:
    - `kyma function init --runtime=nodejs22` was changed to `kyma function init nodejs` 
    - `kyma function init --runtime=python312` -> `kyma function init python`
    - `kyma function init` defaults to `kyma function init nodejs`
- Added in configuration field called `nextStepsInstructions` so that flag changes no longer require changes in CLI

**Screenshot**
<img width="964" height="569" alt="Zrzut ekranu 2025-09-12 o 12 32 28" src="https://github.com/user-attachments/assets/e077c8cd-025b-4258-996b-88d1710866fb" />

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/serverless/issues/1897