### PR TITLE
Take care about the non-served Serverless CR even after second CR was removed

### DIFF
--- a/components/operator/controllers/serverless_controller.go
+++ b/components/operator/controllers/serverless_controller.go
@@ -29,9 +29,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // serverlessReconciler reconciles a Serverless object
@@ -57,6 +60,11 @@ func NewServerlessReconciler(client client.Client, config *rest.Config, recorder
 func (sr *serverlessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Serverless{}, builder.WithPredicates(predicate.NoStatusChangePredicate{})).
+		Watches(&v1alpha1.Serverless{}, &handler.Funcs{
+			// retrigger all Serverless CRs reconciliations when one is deleted
+			// this should at least one Serverless CR is served
+			DeleteFunc: sr.retriggerAllServerlessCRs,
+		}).
 		Watches(&corev1.Service{}, tracing.ServiceCollectorWatcher()).
 		Complete(sr)
 }
@@ -77,4 +85,23 @@ func (sr *serverlessReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	r := sr.initStateMachine(log)
 	return r.Reconcile(ctx, *instance)
+}
+
+func (sr *serverlessReconciler) retriggerAllServerlessCRs(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+	log := sr.log.With("deletion_watcher")
+
+	list := &v1alpha1.ServerlessList{}
+	err := sr.client.List(ctx, list, &client.ListOptions{})
+	if err != nil {
+		log.Errorf("error listing serverless objects: %s", err.Error())
+		return
+	}
+
+	for _, s := range list.Items {
+		log.Debugf("retriggering reconciliation for Serverless %s/%s", s.GetNamespace(), s.GetName())
+		q.Add(ctrl.Request{NamespacedName: client.ObjectKey{
+			Namespace: s.GetNamespace(),
+			Name:      s.GetName(),
+		}})
+	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- requeue all Serverless CRs after one of them is removed (to recalculated the `.status.served` field)
- recalculate the `.status.served` field on every reconciliation to give all resources a "second chance" 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1963