### PR TITLE
Adjust memory limit to prevent OOM when reconciling multiple functions

### DIFF
--- a/config/buildless-serverless/templates/deployment.yaml
+++ b/config/buildless-serverless/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 1Gi
             requests:
               cpu: 10m
               memory: 64Mi


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Setting memory LIMIT to 1Gi (same as in legacy serverless), as beta customer reposrted controlled becoming OOM killed

<img width="787" height="509" alt="Screenshot 2025-10-22 at 11 53 15" src="https://github.com/user-attachments/assets/9e2406d3-68c4-4e78-8618-61eb9b765b8a" />


**Related issue(s)**
https://github.com/kyma-project/serverless/issues/2003
