### PR TITLE
Hold with automated btp tests on release

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -1,6 +1,17 @@
 name: integration tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'The image to test'
+        required: true
+        type: string
+      trigger_btp:
+        description: 'Trigger BTP integration test'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       image:

--- a/.github/workflows/create-release-on-tag.yaml
+++ b/.github/workflows/create-release-on-tag.yaml
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/_integration-tests.yaml
     with:
       image: europe-docker.pkg.dev/kyma-project/prod/serverless-operator:${{ github.ref_name }}
-      trigger_btp: true
+      trigger_btp: false # TODO Bring back once https://jira.tools.sap/browse/NGPBUG-466434 is fixed
 
   publish-release:
     name: Publish release


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Switch off automated acceptance testing for serverless releases - need to be tested manually

**Related issue(s)**
Should be re-enabled once https://github.com/SAP/terraform-provider-btp/issues/1234 is fixed
https://github.com/kyma-project/serverless/issues/2037