### PR TITLE
increase liveness probe time to restart

### DIFF
--- a/config/buildless-serverless/templates/deployment.yaml
+++ b/config/buildless-serverless/templates/deployment.yaml
@@ -55,7 +55,8 @@ spec:
               path: /healthz
               port: {{ .Values.containers.manager.healthzPort }}
             initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: 30
+            failureThreshold: 20
           name: manager
           readinessProbe:
             httpGet:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- temporary increase liveness probe time to restart because of problems with healthz checker when reconciliation queue is filled

**Related issue(s)**
See also:
- https://github.com/orgs/kyma-project/projects/26/views/1?pane=issue&itemId=145713365