### PR TITLE
liveness probe based on metrics

### DIFF
--- a/components/buildless-serverless/internal/controller/health.go
+++ b/components/buildless-serverless/internal/controller/health.go
@@ -83,19 +83,19 @@ func (h *HealthChecker) Checker(req *http.Request) error {
 	h.log.Debug("Liveness handler triggered")
 	// check in metrics if the module was doing something in a last few seconds
 
-	metrics, err := metrics.Registry.Gather()
+	allMetrics, err := metrics.Registry.Gather()
 	if err != nil {
 		h.log.Errorf("can't gather metrics: %v", err)
 		return errors.New("can't gather metrics")
 	}
 
-	workqueueDepthMetric := findMetric(metrics, "workqueue_depth")
+	workqueueDepthMetric := findMetric(allMetrics, "workqueue_depth")
 	if workqueueDepthMetric == nil {
 		h.log.Error("can't find workqueue_depth metric")
 		return errors.New("can't find workqueue_depth metric")
 	}
 
-	totalReconcilesMetric := findMetric(metrics, "controller_runtime_reconcile_total")
+	totalReconcilesMetric := findMetric(allMetrics, "controller_runtime_reconcile_total")
 	if totalReconcilesMetric == nil {
 		h.log.Error("can't find controller_runtime_reconcile_total metric")
 		return errors.New("can't find controller_runtime_reconcile_total metric")

--- a/components/buildless-serverless/internal/controller/health_test.go
+++ b/components/buildless-serverless/internal/controller/health_test.go
@@ -1,15 +1,46 @@
 package controller
 
 import (
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 func TestHealthChecker_Checker(t *testing.T) {
 	log := zap.NewNop().Sugar()
-	t.Run("Success", func(t *testing.T) {
+
+	t.Run("Metrics success", func(t *testing.T) {
+		registerPrometheusGauges(1, 2)
+		//GIVEN
+		timeout := 10 * time.Second
+		checker, _, _ := NewHealthChecker(timeout, log)
+
+		//WHEN
+		err := checker.Checker(nil)
+
+		//THEN
+		require.NoError(t, err)
+	})
+
+	t.Run("Metrics stuck", func(t *testing.T) {
+		registerPrometheusGauges(1, 0)
+		//GIVEN
+		timeout := 10 * time.Second
+		checker, _, _ := NewHealthChecker(timeout, log)
+
+		//WHEN
+		err := checker.Checker(nil)
+
+		//THEN
+		require.Contains(t, err.Error(), "reconcile loop is stuck based on metrics")
+	})
+
+	t.Run("Event success", func(t *testing.T) {
+		registerPrometheusGauges(0, 0)
 		//GIVEN
 		timeout := 10 * time.Second
 		checker, inCh, outCh := NewHealthChecker(timeout, log)
@@ -26,7 +57,8 @@ func TestHealthChecker_Checker(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Timeout", func(t *testing.T) {
+	t.Run("Event timeout", func(t *testing.T) {
+		registerPrometheusGauges(0, 0)
 		//GIVEN
 		timeout := time.Second
 		checker, inCh, _ := NewHealthChecker(timeout, log)
@@ -45,6 +77,7 @@ func TestHealthChecker_Checker(t *testing.T) {
 	})
 
 	t.Run("Can't send check event", func(t *testing.T) {
+		registerPrometheusGauges(0, 0)
 		//GIVEN
 		timeout := time.Second
 		checker, _, _ := NewHealthChecker(timeout, log)
@@ -64,4 +97,28 @@ func TestHealthName(t *testing.T) {
 	// This const is longer than 253 characters to avoid collisions with real k8s objects.
 	require.Greater(t, len(HealthEvent), 253)
 	//THEN
+}
+
+func registerPrometheusGauges(workqueueDepth int, succesfullReconciliations int) {
+	metrics.Registry = prometheus.NewRegistry()
+
+	workqueueGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "workqueue_depth",
+		Help: "Current depth of workqueue",
+	}, []string{"controller", "name"})
+	workqueueGauge.WithLabelValues("function", "function").Set(float64(workqueueDepth))
+	metrics.Registry.MustRegister(workqueueGauge)
+
+	reconcileTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "controller_runtime_reconcile_total",
+			Help: "Total number of reconciliations per controller",
+		},
+		[]string{"controller", "result"},
+	)
+	reconcileTotal.WithLabelValues("function", "error").Add(0)
+	reconcileTotal.WithLabelValues("function", "requeue").Add(0)
+	reconcileTotal.WithLabelValues("function", "requeueAfter").Add(0)
+	reconcileTotal.WithLabelValues("function", "success").Add(float64(succesfullReconciliations))
+	metrics.Registry.MustRegister(reconcileTotal)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Check readiness based on metrics
    - if the reconciliation queue is empty then check liveness the old way, by issuing a request
    - if the queue is not empty check if the number of processed event is higher than in the previous liveness check

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #2146
- #2149