### PR TITLE
Revert "increase liveness probe time to restart (#2149)"

### DIFF
--- a/config/buildless-serverless/templates/deployment.yaml
+++ b/config/buildless-serverless/templates/deployment.yaml
@@ -55,8 +55,7 @@ spec:
               path: /healthz
               port: {{ .Values.containers.manager.healthzPort }}
             initialDelaySeconds: 15
-            periodSeconds: 30
-            failureThreshold: 20
+            periodSeconds: 20
           name: manager
           readinessProbe:
             httpGet:


### PR DESCRIPTION
This reverts commit 757790f2328bd99be09894ce63e811a1f81a8772.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Revert "increase liveness probe time to restart (#2149)"


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/2146
- #2149