### PR TITLE
Fix nodejs22 build

### DIFF
--- a/components/runtimes/nodejs22/Dockerfile
+++ b/components/runtimes/nodejs22/Dockerfile
@@ -4,12 +4,14 @@ FROM europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/nginx/alpine-fips:
 ENV NODE_VERSION=22.22.0-r0
 # use Ada version compatible with the Node version
 ENV ADA_VERSION=2.9.2-r4
+# use NPM version compatible with the Node version
+ENV NPM_VERSION=11.6.4-r0
 
 # Update repositories to prioritize v3.22 and allow downgrades
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.22/main" > /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/v3.22/community" >> /etc/apk/repositories && \
     apk update && \
-     apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.22/main ada-libs=${ADA_VERSION} nodejs=${NODE_VERSION} npm
+    apk add --no-cache --allow-untrusted --force-overwrite ada-libs=${ADA_VERSION} nodejs=${NODE_VERSION} npm=${NPM_VERSION}
 
 # FIPS
 COPY openssl.cnf /etc/ssl/openssl.cnf


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- use stale alpine repository (from [alpine 3.22](https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.22&repo=main&arch=x86_64&origin=&flagged=&maintainer=)) to install nodejs22 (because [3.23](https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.23&repo=main&arch=x86_64&origin=&flagged=&maintainer=) contains the nodejs24 only)
- upgrade nodejs22 version to (from the `22.16.0-r2` to the `22.22.0-r0`)
- base changes on [this PR](https://github.com/kyma-project/serverless/pull/2162)