### PR TITLE
Python 3.14 configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,21 @@ updates:
       - dependency-name: kyma-project/prod/external/library/python
         update-types: ["version-update:semver-minor"]
   - package-ecosystem: "docker"
+    directory: "/components/runtimes/python314"
+    labels:
+      - "area/dependency"
+      - "kind/chore"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "python314"
+      include: "scope"
+    ignore:
+      # ignore minor python updates, e.g. 3.9 -> 3.12
+      - dependency-name: kyma-project/prod/external/library/python
+        update-types: ["version-update:semver-minor"]
+  
+  - package-ecosystem: "docker"
     directory: "/components/runtimes/nodejs20"
     labels:
       - "area/dependency"
@@ -133,6 +148,10 @@ updates:
     commit-message:
       prefix: "nodejs22"
       include: "scope"
+    ignore:
+      # ignore minor node updates, e.g. 20.x -> 21.x
+      - dependency-name: kyma-project/prod/external/library/node
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/components/runtimes/nodejs24"
     labels:
@@ -143,6 +162,10 @@ updates:
     commit-message:
       prefix: "nodejs24"
       include: "scope"
+    ignore:
+      # ignore minor node updates, e.g. 20.x -> 21.x
+      - dependency-name: kyma-project/prod/external/library/node
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/components/runtimes/python312"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- configure dependatbot for python 3.14
- configure dependabot to not bump major node versions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/2083#issue-3686211056