### PR TITLE
Fix BTP e2e tests even though deny-all policies are not permitted

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -242,7 +242,6 @@ jobs:
       - name: run tests
         run: |
           kubectl create namespace kyma-system || true
-          kubectl apply -f tests/fixtures/deny-all-networkpolicy.yaml
           make install-serverless-custom-operator
           make -C tests/serverless serverless-integration
           kubectl delete functions.serverless.kyma-project.io -A --all


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Deny-all policies are blocked by admission policies on managed clusters
https://github.com/kyma-project/serverless/actions/runs/22845483791/job/66261847486#step:6:22