### PR TITLE
skip legacy serverless scenario in operator tests

### DIFF
--- a/tests/operator/main.go
+++ b/tests/operator/main.go
@@ -115,8 +115,8 @@ func main() {
 
 func runScenario(testutil *utils.TestUtils) error {
 
-	if testutil.FipsMode && testutil.LegacyMode {
-		testutil.Logger.Info("Skipping FIPS mode test for legacy serverless")
+	if testutil.LegacyMode {
+		testutil.Logger.Info("Skipping legacy serverless scenario")
 		return nil
 	}
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- skip legacy serverless scenario in operator tests

**Related issue(s)**
See also:
- #2423 