### PR TITLE
Remove reference to legacy serverless chart from docs

### DIFF
--- a/docs/user/technical-reference/07-70-function-specification.md
+++ b/docs/user/technical-reference/07-70-function-specification.md
@@ -224,7 +224,4 @@ You can use a custom runtime image to override the existing one. Your image must
 - Fetch sources from the path under the `KUBELESS_INSTALL_VOLUME` environment
 - Security support. Kyma runtimes are secure by default. You only need to protect your images.
 
-> [!NOTE]
-> For better understanding, you can look at the [main Docker files](../../../config/serverless/templates/runtimes.yaml). They are responsible for building the final image based on the `base_image` argument. You, as a user, can override it and what we are doing in [this tutorial](../tutorials/01-110-override-runtime-image.md).
-
 Every Function's Pods container has the same system environments, which helps you configure the Functions server. For more information, read the [Environment variables](05-20-env-variables.md) page.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove reference to legacy serverless chart from docs

**Related issue(s)**
See also:
- #2423 