### PR TITLE
docs: sync configuring-logging with DITA version

### DIFF
--- a/docs/user/00-70-configuring-logging.md
+++ b/docs/user/00-70-configuring-logging.md
@@ -13,10 +13,12 @@ From the least to the most verbose: `fatal`, `panic`, `dpanic`, `error`, `warn`,
 
 ## Supported Log Formats
 
+The supported log formats are the following:
+
 - `json` - Structured JSON format (default)
 - `console` - Human-readable console format
 
-## Configure Serverless Controller
+## Configuring Serverless Controller
 
 Update the log configuration by modifying the Serverless CR in the `kyma-system` namespace:
 
@@ -41,6 +43,9 @@ Verify the change:
 
 Update the log configuration in the `serverless-operator-log-config` ConfigMap in the `kyma-system` namespace:
 
+> [!NOTE]
+> You can't dynamically change the log format for the Serverless Operator. If you want to change it, update the ConfigMap and restart the Pods.
+
    ```bash
    # Change log level
    kubectl patch configmap serverless-operator-log-config -n kyma-system --type merge -p '{"data":{"log-config.yaml":"logLevel: debug"}}'
@@ -54,6 +59,3 @@ Verify the change:
    ```bash
    kubectl logs -n kyma-system -l control-plane=operator
    ```
-
-> [!NOTE]
-> It is not possible to dynamically change the log format for the Serverless Operator. If you want to change it, update the ConfigMap and restart the Pods.


### PR DESCRIPTION
- Fix section title: "Configure" -> "Configuring Serverless Controller"
- Add missing intro sentence to Supported Log Formats section
- Move Serverless Operator note before code blocks
- Update note wording to match DITA: "You can't dynamically change..."

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- docs: sync configuring-logging with DITA version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
