### PR TITLE
sec: harden pull_request_target workflows against secret exfiltration

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -30,11 +30,6 @@ jobs:
     outputs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - if: ${{ !startsWith(github.event_name, 'pull_request') }}
         name: Get the latest tag
         id: get_tag

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -114,7 +114,7 @@ jobs:
         run: make -C tests/serverless cluster-info
   
   fips-mode-serverless-integration-test:
-    if: ${{ !startsWith(github.event_name, 'pull_request') || github.event.pull_request.draft == false }}
+    if: ${{ !startsWith(github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -140,7 +140,7 @@ jobs:
         run: make -C tests/serverless cluster-info
 
   git-auth-integration-test:
-    if: ${{ !startsWith(github.event_name, 'pull_request') || github.event.pull_request.draft == false }}
+    if: ${{ !startsWith(github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -167,7 +167,7 @@ jobs:
         run: make -C tests/serverless cluster-info
   
   fips-mode-git-auth-integration-test:
-    if: ${{ !startsWith(github.event_name, 'pull_request') || github.event.pull_request.draft == false }}
+    if: ${{ !startsWith(github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -35,7 +35,6 @@ jobs:
 
   integrations:
     needs: builds
-    secrets: inherit
     uses: kyma-project/serverless/.github/workflows/_integration-tests.yaml@main
     with:
       img_directory: "dev"


### PR DESCRIPTION
## Summary

- Remove unnecessary PR code checkout from `compute-tags` job in `_build.yaml` — the job only reads GitHub context variables and never uses checked-out files, so the checkout was exposing PR code in a privileged context for no reason
- Skip secret-dependent integration tests (`fips-mode-serverless`, `git-auth`, `fips-mode-git-auth`) on PR events in `_integration-tests.yaml` — these jobs require `RESTRICTED_REPO_SA_BASE64` and git auth credentials that must not be accessible to untrusted PR code
- Remove `secrets: inherit` from the `integrations` job in `pull.yaml` — no secrets are needed for the tests that still run on PRs

## Security context

`pull_request_target` runs with write permissions and secret access in the base branch context. Combined with `secrets: inherit`, a malicious fork PR could exfiltrate all repository secrets. These changes ensure secrets are never passed to workflows that execute untrusted PR code.

The `pull-release-*.yaml` workflows are auto-generated from `pull.yaml` via `create-release-pull.yaml`, so they will inherit this fix when regenerated.

## Test plan

- [ ] Verify non-secret integration tests (`operator-integration-test`, `serverless-integration-test`, `rbac-integration-test`) still run on PRs
- [ ] Verify `fips-mode-*` and `git-auth-*` jobs are skipped on PR events
- [ ] Verify builds job no longer checks out PR code in `compute-tags`
- [ ] Verify push-to-main still runs all jobs including secret-dependent ones