### PR TITLE
sec: scope id-token: write to builds job only in pull workflow

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -7,7 +7,6 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -22,6 +21,9 @@ jobs:
     uses: kyma-project/serverless/.github/workflows/_images-verify.yaml@main
 
   builds:
+    permissions:
+      id-token: write # This is required for requesting the JWT token (GCP Workload Identity)
+      contents: read
     uses: kyma-project/serverless/.github/workflows/_build.yaml@main
     with:
       purpose: "dev"


### PR DESCRIPTION
## Summary

- `id-token: write` was set at workflow level, granting OIDC token access to **all** jobs including those that checkout and execute untrusted PR branch code
- Moved `id-token: write` to the `builds` job only — the only job that actually needs it (calls `image-builder.yml` which uses GCP Workload Identity Federation)
- All other jobs (`unit-tests`, `gitleaks`, `images-verify`, `check-fips-image-versions`, `integrations`) now run without the OIDC permission

## Security impact

Under `pull_request_target`, jobs can execute code from untrusted forks. Scoping `id-token: write` to only the job that needs it reduces the blast radius if any other job were exploited. This follows the same principle as #2518 and #2521.

## Test plan

- [ ] Verify `builds` job still succeeds (image push to GCP works)
- [ ] Verify other jobs are unaffected