### PR TITLE
Add a gate that checks the type of contributor before running builds

### DIFF
--- a/.github/workflows/build-performance-test-runner.yaml
+++ b/.github/workflows/build-performance-test-runner.yaml
@@ -11,7 +11,15 @@ on:
       - "tests/performance/**"
 
 jobs:
+  select-environment:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    steps:
+      - name: Approved
+        run: echo "Build approved, environment selected"
+
   compute-tags:
+    needs: select-environment
     runs-on: ubuntu-latest
     permissions:
       contents: read # This is required for actions/checkout

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -20,11 +20,20 @@ jobs:
     if: github.event.pull_request.base.ref == 'main'
     uses: kyma-project/serverless/.github/workflows/_images-verify.yaml@main
 
+  select-environment:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    steps:
+      - name: Approved
+        run: echo "Build approved, environment selected"
+
+
   builds:
-    permissions:
-      id-token: write # This is required for requesting the JWT token (GCP Workload Identity)
-      contents: read
+    needs: select-environment
     uses: kyma-project/serverless/.github/workflows/_build.yaml@main
+    permissions:
+        id-token: write # This is required for requesting the JWT token
+        contents: read # This is required for actions/checkout
     with:
       purpose: "dev"
       img_directory: "dev"
@@ -37,6 +46,7 @@ jobs:
 
   integrations:
     needs: builds
+    secrets: inherit
     uses: kyma-project/serverless/.github/workflows/_integration-tests.yaml@main
     with:
       img_directory: "dev"

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Approved
         run: echo "Build approved, environment selected"
 
-
   builds:
     needs: select-environment
     uses: kyma-project/serverless/.github/workflows/_build.yaml@main

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -45,7 +45,6 @@ jobs:
 
   integrations:
     needs: builds
-    secrets: inherit
     uses: kyma-project/serverless/.github/workflows/_integration-tests.yaml@main
     with:
       img_directory: "dev"


### PR DESCRIPTION
**Description**
Environment in context of this PR mean the environments configured in settings of this repository
External contributors require team member approval so if someone is not part of @kyma-project/otters and neither is owner of this repository he will fall under restricted environment and require our manual approval to proceed with builds, if a team member makes a contribution the build will run automatically cause it will fall into the "internal" environment


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
