### PR TITLE
Add namespaceSelector to metrics NetworkPolicy selectors

### DIFF
--- a/config/buildless-serverless/templates/network-policies.yaml
+++ b/config/buildless-serverless/templates/network-policies.yaml
@@ -44,10 +44,16 @@ spec:
   - Ingress
   ingress:
   - from:
-    - podSelector:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kyma-system
+      podSelector:
         matchLabels:
           app.kubernetes.io/instance: rma
-    - podSelector:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kyma-system
+      podSelector:
         matchLabels:
           networking.kyma-project.io/metrics-scraping: allowed
     ports:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- allow metrics scraping from pods in kyma-system by adding namespaceSelector to RMA and metrics-scraping selectors in metrics NetworkPolicy.

**Related issue(s)**
See also:
- https://github.tools.sap/kyma/backlog/issues/9617