### PR TITLE
fix(serverless): support commit SHAs and tags in gitRepository.reference

### DIFF
--- a/components/buildless-serverless/cmd/jobinit/main.go
+++ b/components/buildless-serverless/cmd/jobinit/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -20,6 +21,8 @@ import (
 )
 
 const envPrefix = "APP"
+
+var commitSHARegexp = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 
 type initConfig struct {
 	RepositoryURL         string
@@ -63,12 +66,29 @@ func main() {
 }
 
 func clone(c initConfig, auth transport.AuthMethod) error {
-	r, err := git.PlainClone(c.DestinationPath, false, &git.CloneOptions{
-		URL:           c.RepositoryURL,
-		ReferenceName: plumbing.ReferenceName(c.RepositoryReference),
-		SingleBranch:  true,
-		Auth:          auth,
-	})
+	cloneOpts := &git.CloneOptions{
+		URL:  c.RepositoryURL,
+		Auth: auth,
+	}
+
+	// For a commit SHA the controller already resolved the exact hash; clone the
+	// default branch and let the checkout below land on it.  For a named reference
+	// (branch or tag) use SingleBranch for efficiency: try refs/heads/ first,
+	// fall back to refs/tags/ if the branch clone fails.
+	if !commitSHARegexp.MatchString(c.RepositoryReference) {
+		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(c.RepositoryReference)
+		cloneOpts.SingleBranch = true
+	}
+
+	r, err := git.PlainClone(c.DestinationPath, false, cloneOpts)
+	if err != nil && !commitSHARegexp.MatchString(c.RepositoryReference) {
+		// Branch ref not found — retry as a tag.
+		cloneOpts.ReferenceName = plumbing.NewTagReferenceName(c.RepositoryReference)
+		if err2 := os.RemoveAll(c.DestinationPath); err2 != nil {
+			return errors.Wrap(err2, "while cleaning destination path before tag retry")
+		}
+		r, err = git.PlainClone(c.DestinationPath, false, cloneOpts)
+	}
 	if err != nil {
 		return err
 	}

--- a/components/buildless-serverless/internal/controller/git/commit_checker.go
+++ b/components/buildless-serverless/internal/controller/git/commit_checker.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"regexp"
+
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
@@ -8,6 +10,8 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/pkg/errors"
 )
+
+var commitSHARegexp = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 
 func init() {
 	// required by Azure Devops (works with Github, Gitlab, Bitbucket)
@@ -18,6 +22,11 @@ func init() {
 }
 
 func GetLatestCommit(url, reference string, gitAuth *GitAuth) (string, error) {
+	// A full 40-character SHA is already the commit — no remote listing needed.
+	if commitSHARegexp.MatchString(reference) {
+		return reference, nil
+	}
+
 	repo, err := git.Init(memory.NewStorage(), nil)
 	if err != nil {
 		return "", err

--- a/components/buildless-serverless/internal/controller/git/commit_checker_test.go
+++ b/components/buildless-serverless/internal/controller/git/commit_checker_test.go
@@ -1,0 +1,28 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetLatestCommit_CommitSHA(t *testing.T) {
+	t.Run("returns commit SHA directly without remote call", func(t *testing.T) {
+		sha := "25ea1d5577a4362500fc77d4ea9a2bfeb3665c05"
+		result, err := GetLatestCommit("http://should-not-be-called", sha, nil)
+		require.NoError(t, err)
+		require.Equal(t, sha, result)
+	})
+
+	t.Run("does not treat short hex string as commit SHA", func(t *testing.T) {
+		// A 7-char abbreviated SHA should NOT be treated as a full commit SHA —
+		// it would fail on an unreachable URL just like a branch name would.
+		_, err := GetLatestCommit("http://unreachable.invalid", "25ea1d5", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("does not treat non-hex string as commit SHA", func(t *testing.T) {
+		_, err := GetLatestCommit("http://unreachable.invalid", "main", nil)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Problem

The Function CR API documents that `source.gitRepository.reference` accepts a branch name, tag, or commit SHA, but since 1.12.0 only branch names work.

### Root cause — two bugs

**1. `commit_checker.go` — commit SHAs rejected at validation time**

`GetLatestCommit()` calls `remote.List()` and filters to only `refs/heads/*` and `refs/tags/*`. A bare 40-char SHA never appears in that listing → always returns `"reference not found"`.

**2. `jobinit/main.go` — tags and SHAs fail at clone time**

`clone()` passed the raw reference string as `plumbing.ReferenceName()`, which go-git interprets as `refs/heads/<value>`. A tag or commit SHA therefore tried to clone `refs/heads/<tag>` or `refs/heads/<sha>` which does not exist → `"couldn't find remote ref refs/heads/..."`.

## Fix

- **`commit_checker.go`**: detect a full 40-char hex SHA and return it directly — no remote call needed, the SHA *is* the commit.
- **`jobinit/main.go`**: use `plumbing.NewBranchReferenceName` for branches (with a fallback to `plumbing.NewTagReferenceName` on failure), and skip `ReferenceName`/`SingleBranch` entirely for commit SHAs so the clone fetches the default branch before the existing checkout-by-hash step lands on the correct commit.

## Scope / limitations

**Full 40-char commit SHAs** are supported. Abbreviated short SHAs (e.g. `25ea1d5`) are intentionally not supported: they cannot be resolved via the remote protocol and would require a full clone just to expand the prefix — negating the lightweight `remote.List()` optimisation introduced in 1.12.0.

Supported `reference` values after this fix:
| Value | Example | Supported |
|---|---|---|
| Branch name | `main` | ✅ |
| Tag name | `v1.2.3` | ✅ |
| Full commit SHA (40 hex chars) | `25ea1d5577a4362500fc77d4ea9a2bfeb3665c05` | ✅ |
| Short/abbreviated SHA | `25ea1d5` | ❌ not feasible |

## Testing

- Added unit tests for the SHA fast-path in `commit_checker_test.go`
- All existing tests pass