### PR TITLE
fix(ci): disable integration tests in pull_request_target to fix fork checkout

### DIFF
--- a/.github/workflows/pull-build.yaml
+++ b/.github/workflows/pull-build.yaml
@@ -28,9 +28,12 @@ jobs:
       img_directory: "dev"
       img_version: PR-${{ github.event.number }}
 
-  integrations:
-    needs: builds
-    uses: ./.github/workflows/_integration-tests.yaml
-    with:
-      img_directory: "dev"
-      img_version: PR-${{ github.event.number }}
+  # Integration tests are intentionally disabled for pull_request_target.
+  # actions/checkout@v7 blocks fork checkouts in pull_request_target by default (safer-pull_request_target-defaults).
+  # Only the build job above runs here - it uses id-token to push images but does not expose secrets to untrusted fork code.
+  # integrations:
+  #   needs: builds
+  #   uses: ./.github/workflows/_integration-tests.yaml
+  #   with:
+  #     img_directory: "dev"
+  #     img_version: PR-${{ github.event.number }}


### PR DESCRIPTION
## Summary

- `actions/checkout@v7` introduced safer defaults for `pull_request_target`: fork checkouts are now blocked by default ([changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)), effective for all floating tags (e.g. `@v7`) from July 16, 2026
- Integration tests in `pull-build.yaml` checked out fork code in `pull_request_target` context, which is now blocked
- Disabled integration tests from `pull-build.yaml` — only the build job remains, which uses `id-token` to push images but does not expose secrets to untrusted fork code
