### PR TITLE
fix: add node:26.5.0-alpine3.24 to external-images.yaml (prereq for #2635)

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -7,6 +7,9 @@ images:
   - source: "ghcr.io/nginx/alpine-fips@sha256:15cf5753964eca17557083313d2a39e6a3cc659a5a2143ecebc476b14cc687e6"
     tag: "0.5.0-alpine3.23"
   # https://hub.docker.com/layers/library/node/26-alpine
+  - source: "node@sha256:c9f02360d2bc66e709b300214395588acd2d3603f600db8141117e67c0faf4ff"
+    tag: "26.5.0-alpine3.24"
+  # https://hub.docker.com/layers/library/node/26-alpine
   - source: "node@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9"
     tag: "26.4.0-alpine3.24"
   # https://hub.docker.com/layers/library/node/24-alpine


### PR DESCRIPTION
## Summary

Prerequisite sync PR for kyma-project/serverless#2635.

Dependabot bumped `node-fips:26.4.0-dev → 26.5.0-dev` in the nodejs26 Dockerfile, but the non-FIPS `node:26.4.0-alpine3.24` image is still referenced. The `check-fips-image-versions` CI check requires both FROM lines to use the same version.

This PR adds `node:26.5.0-alpine3.24` to `external-images.yaml` so the image is available in the project's registry mirror before the Dependabot PR is merged.

## Steps
1. Merge this PR first (image sync)
2. Then merge kyma-project/serverless#2635 (which now has the non-FIPS FROM bumped to match)